### PR TITLE
GDE-11: Enables the multilingual modules for content.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -60,7 +60,9 @@
         },
         "patches": {
             "drupal/core": {
-                "2033275: Contextual links broken because of JS error": "https://www.drupal.org/files/issues/contextual_links_broken-2033275-10.patch"
+                "2033275: Contextual links broken because of JS error": "https://www.drupal.org/files/issues/contextual_links_broken-2033275-10.patch",
+                "2884801: Views contextual duplication": "./patches/drupal/core/views-block-context-duplication.patch",
+                "2661880: Quickedit undefined": "https://www.drupal.org/files/issues/quickedit-undefined-attr-2661880-14.patch"
             },
             "drupal/govcms_dlm": {
                 "2883963: Hook Help": "https://www.drupal.org/files/issues/hook-help-d8-api-2883963-1.patch",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "606b330949e4af6cf229843904f2bc18",
+    "content-hash": "37c91df7671be47808fc57a1fff57411",
     "packages": [
         {
             "name": "acquia/blt",
@@ -1855,16 +1855,16 @@
         },
         {
             "name": "drupal/core",
-            "version": "8.3.2",
+            "version": "8.3.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/drupal/core.git",
-                "reference": "82c432cfe728458538d4826c9c4be57dcf35443b"
+                "reference": "98da955d81c79f1a753536ab9c9dad5f80a72922"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/drupal/core/zipball/82c432cfe728458538d4826c9c4be57dcf35443b",
-                "reference": "82c432cfe728458538d4826c9c4be57dcf35443b",
+                "url": "https://api.github.com/repos/drupal/core/zipball/98da955d81c79f1a753536ab9c9dad5f80a72922",
+                "reference": "98da955d81c79f1a753536ab9c9dad5f80a72922",
                 "shasum": ""
             },
             "require": {
@@ -2018,6 +2018,8 @@
             "extra": {
                 "patches_applied": {
                     "2033275: Contextual links broken because of JS error": "https://www.drupal.org/files/issues/contextual_links_broken-2033275-10.patch",
+                    "2884801: Views contextual duplication": "./patches/drupal/core/views-block-context-duplication.patch",
+                    "2661880: Quickedit undefined": "https://www.drupal.org/files/issues/quickedit-undefined-attr-2661880-14.patch",
                     "Clear Twig caches on deploys": "https://www.drupal.org/files/issues/no_reliable_method-2752961-29.patch",
                     "2652138 - ImageFormatter does not support SVGs": "https://www.drupal.org/files/issues/2652138-41.patch",
                     "1356276 - Allow profiles to provide a base/parent profile and load them in the correct order": "https://www.drupal.org/files/issues/1356276-303.patch"
@@ -2044,7 +2046,7 @@
                 "GPL-2.0+"
             ],
             "description": "Drupal is an open source content management platform powering millions of websites and applications.",
-            "time": "2017-05-03T17:12:42+00:00"
+            "time": "2017-06-07T17:35:30+00:00"
         },
         {
             "name": "drupal/ctools",
@@ -2769,7 +2771,7 @@
             "dist": {
                 "type": "zip",
                 "url": "https://ftp.drupal.org/files/projects/govcms_dlm-8.x-1.1.zip",
-                "reference": null,
+                "reference": "8.x-1.1",
                 "shasum": "b36fa2d311ea2fc1beff1bc58de8b387a349651a"
             },
             "require": {

--- a/config/default/block.block.govcms_footer.yml
+++ b/config/default/block.block.govcms_footer.yml
@@ -13,7 +13,7 @@ _core:
 id: govcms_footer
 theme: govcms
 region: footer
-weight: -3
+weight: -6
 provider: null
 plugin: 'system_menu_block:footer'
 settings:

--- a/config/default/block.block.languageswitcher.yml
+++ b/config/default/block.block.languageswitcher.yml
@@ -1,0 +1,20 @@
+uuid: 12a66ded-b482-4f92-b288-4a80798d4e0e
+langcode: en
+status: true
+dependencies:
+  module:
+    - language
+  theme:
+    - govcms
+id: languageswitcher
+theme: govcms
+region: footer
+weight: -7
+provider: null
+plugin: 'language_block:language_interface'
+settings:
+  id: 'language_block:language_interface'
+  label: 'Language switcher'
+  provider: language
+  label_display: visible
+visibility: {  }

--- a/config/default/core.base_field_override.block_content.basic.changed.yml
+++ b/config/default/core.base_field_override.block_content.basic.changed.yml
@@ -11,7 +11,7 @@ bundle: basic
 label: Changed
 description: 'The time that the custom block was last edited.'
 required: false
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings: {  }

--- a/config/default/core.base_field_override.block_content.basic.changed.yml
+++ b/config/default/core.base_field_override.block_content.basic.changed.yml
@@ -1,0 +1,18 @@
+uuid: 94d9cd3b-a4a3-4238-b4cf-49b3b18a0f22
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.basic
+id: block_content.basic.changed
+field_name: changed
+entity_type: block_content
+bundle: basic
+label: Changed
+description: 'The time that the custom block was last edited.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: changed

--- a/config/default/core.base_field_override.block_content.basic.info.yml
+++ b/config/default/core.base_field_override.block_content.basic.info.yml
@@ -11,7 +11,7 @@ bundle: basic
 label: 'Block description'
 description: 'A brief description of your block.'
 required: true
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings: {  }

--- a/config/default/core.base_field_override.block_content.basic.info.yml
+++ b/config/default/core.base_field_override.block_content.basic.info.yml
@@ -1,0 +1,18 @@
+uuid: fd31c5b6-a78b-42ae-9064-212dce4953b2
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.basic
+id: block_content.basic.info
+field_name: info
+entity_type: block_content
+bundle: basic
+label: 'Block description'
+description: 'A brief description of your block.'
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/default/core.base_field_override.block_content.basic.moderation_state.yml
+++ b/config/default/core.base_field_override.block_content.basic.moderation_state.yml
@@ -11,7 +11,7 @@ bundle: basic
 label: 'Moderation state'
 description: 'The moderation state of this piece of content.'
 required: false
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings:

--- a/config/default/core.base_field_override.block_content.basic.moderation_state.yml
+++ b/config/default/core.base_field_override.block_content.basic.moderation_state.yml
@@ -1,0 +1,20 @@
+uuid: 0eedbf78-0439-47e3-ad28-becc3264a111
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.basic
+id: block_content.basic.moderation_state
+field_name: moderation_state
+entity_type: block_content
+bundle: basic
+label: 'Moderation state'
+description: 'The moderation state of this piece of content.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: default
+  handler_settings: {  }
+field_type: entity_reference

--- a/config/default/core.base_field_override.block_content.block_with_background.changed.yml
+++ b/config/default/core.base_field_override.block_content.block_with_background.changed.yml
@@ -11,7 +11,7 @@ bundle: block_with_background
 label: Changed
 description: 'The time that the custom block was last edited.'
 required: false
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings: {  }

--- a/config/default/core.base_field_override.block_content.block_with_background.changed.yml
+++ b/config/default/core.base_field_override.block_content.block_with_background.changed.yml
@@ -1,0 +1,18 @@
+uuid: 6cbb6330-a8bb-4f25-b060-ff1dc4fe10e2
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.block_with_background
+id: block_content.block_with_background.changed
+field_name: changed
+entity_type: block_content
+bundle: block_with_background
+label: Changed
+description: 'The time that the custom block was last edited.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: changed

--- a/config/default/core.base_field_override.block_content.block_with_background.info.yml
+++ b/config/default/core.base_field_override.block_content.block_with_background.info.yml
@@ -1,0 +1,18 @@
+uuid: a57fc3b1-641a-4a94-b8b8-c05973ff8786
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.block_with_background
+id: block_content.block_with_background.info
+field_name: info
+entity_type: block_content
+bundle: block_with_background
+label: 'Block description'
+description: 'A brief description of your block.'
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/default/core.base_field_override.block_content.block_with_background.info.yml
+++ b/config/default/core.base_field_override.block_content.block_with_background.info.yml
@@ -11,7 +11,7 @@ bundle: block_with_background
 label: 'Block description'
 description: 'A brief description of your block.'
 required: true
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings: {  }

--- a/config/default/core.base_field_override.block_content.block_with_background.moderation_state.yml
+++ b/config/default/core.base_field_override.block_content.block_with_background.moderation_state.yml
@@ -11,7 +11,7 @@ bundle: block_with_background
 label: 'Moderation state'
 description: 'The moderation state of this piece of content.'
 required: false
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings:

--- a/config/default/core.base_field_override.block_content.block_with_background.moderation_state.yml
+++ b/config/default/core.base_field_override.block_content.block_with_background.moderation_state.yml
@@ -1,0 +1,20 @@
+uuid: 941e1a75-351a-4528-9b7a-c76e930da3db
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.block_with_background
+id: block_content.block_with_background.moderation_state
+field_name: moderation_state
+entity_type: block_content
+bundle: block_with_background
+label: 'Moderation state'
+description: 'The moderation state of this piece of content.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: default
+  handler_settings: {  }
+field_type: entity_reference

--- a/config/default/core.base_field_override.media.document.changed.yml
+++ b/config/default/core.base_field_override.media.document.changed.yml
@@ -1,0 +1,18 @@
+uuid: 98051557-6d1d-40b8-8a3e-c91e0a3cb042
+langcode: en
+status: true
+dependencies:
+  config:
+    - media_entity.bundle.document
+id: media.document.changed
+field_name: changed
+entity_type: media
+bundle: document
+label: Changed
+description: 'The time that the media was last edited.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: changed

--- a/config/default/core.base_field_override.media.document.created.yml
+++ b/config/default/core.base_field_override.media.document.created.yml
@@ -1,0 +1,18 @@
+uuid: 3c99376e-278e-4a0b-85f4-ccfd8751e2cd
+langcode: en
+status: true
+dependencies:
+  config:
+    - media_entity.bundle.document
+id: media.document.created
+field_name: created
+entity_type: media
+bundle: document
+label: Created
+description: 'The time that the media was created.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: created

--- a/config/default/core.base_field_override.media.document.moderation_state.yml
+++ b/config/default/core.base_field_override.media.document.moderation_state.yml
@@ -1,0 +1,20 @@
+uuid: 32085456-0a91-45db-a3b4-903459e0278c
+langcode: en
+status: true
+dependencies:
+  config:
+    - media_entity.bundle.document
+id: media.document.moderation_state
+field_name: moderation_state
+entity_type: media
+bundle: document
+label: 'Moderation state'
+description: 'The moderation state of this piece of content.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: default
+  handler_settings: {  }
+field_type: entity_reference

--- a/config/default/core.base_field_override.media.document.name.yml
+++ b/config/default/core.base_field_override.media.document.name.yml
@@ -1,0 +1,20 @@
+uuid: 8b37dc36-dbe0-4f6c-a295-b6b0f279f28f
+langcode: en
+status: true
+dependencies:
+  config:
+    - media_entity.bundle.document
+id: media.document.name
+field_name: name
+entity_type: media
+bundle: document
+label: 'Media name'
+description: 'The name of this media.'
+required: true
+translatable: false
+default_value:
+  -
+    value: ''
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/default/core.base_field_override.media.document.revision_log.yml
+++ b/config/default/core.base_field_override.media.document.revision_log.yml
@@ -1,0 +1,18 @@
+uuid: d1a21894-5710-4787-89ba-673963ff8e41
+langcode: en
+status: true
+dependencies:
+  config:
+    - media_entity.bundle.document
+id: media.document.revision_log
+field_name: revision_log
+entity_type: media
+bundle: document
+label: 'Revision Log'
+description: 'The log entry explaining the changes in this revision.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string_long

--- a/config/default/core.base_field_override.media.document.status.yml
+++ b/config/default/core.base_field_override.media.document.status.yml
@@ -1,0 +1,22 @@
+uuid: 02a3150b-ec6b-4c81-9a4e-a05cfba85697
+langcode: en
+status: true
+dependencies:
+  config:
+    - media_entity.bundle.document
+id: media.document.status
+field_name: status
+entity_type: media
+bundle: document
+label: 'Publishing status'
+description: 'A boolean indicating whether the media is published.'
+required: false
+translatable: false
+default_value:
+  -
+    value: 1
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/config/default/core.base_field_override.media.document.uid.yml
+++ b/config/default/core.base_field_override.media.document.uid.yml
@@ -1,0 +1,20 @@
+uuid: 723ce960-8930-4fac-a61e-5267f31e39b5
+langcode: en
+status: true
+dependencies:
+  config:
+    - media_entity.bundle.document
+id: media.document.uid
+field_name: uid
+entity_type: media
+bundle: document
+label: 'Publisher ID'
+description: 'The user ID of the media publisher.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: 'Drupal\media_entity\Entity\Media::getCurrentUserId'
+settings:
+  handler: default
+  handler_settings: {  }
+field_type: entity_reference

--- a/config/default/core.base_field_override.media.image.changed.yml
+++ b/config/default/core.base_field_override.media.image.changed.yml
@@ -1,0 +1,18 @@
+uuid: 17e12d50-d83d-4f6d-86b0-cd51536813d1
+langcode: en
+status: true
+dependencies:
+  config:
+    - media_entity.bundle.image
+id: media.image.changed
+field_name: changed
+entity_type: media
+bundle: image
+label: Changed
+description: 'The time that the media was last edited.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: changed

--- a/config/default/core.base_field_override.media.image.created.yml
+++ b/config/default/core.base_field_override.media.image.created.yml
@@ -1,0 +1,18 @@
+uuid: 5df4a4e9-2b57-4fc9-9242-652316603a15
+langcode: en
+status: true
+dependencies:
+  config:
+    - media_entity.bundle.image
+id: media.image.created
+field_name: created
+entity_type: media
+bundle: image
+label: Created
+description: 'The time that the media was created.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: created

--- a/config/default/core.base_field_override.media.image.moderation_state.yml
+++ b/config/default/core.base_field_override.media.image.moderation_state.yml
@@ -1,0 +1,20 @@
+uuid: ee996eb6-986b-4207-a66d-5466ac9be28c
+langcode: en
+status: true
+dependencies:
+  config:
+    - media_entity.bundle.image
+id: media.image.moderation_state
+field_name: moderation_state
+entity_type: media
+bundle: image
+label: 'Moderation state'
+description: 'The moderation state of this piece of content.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: default
+  handler_settings: {  }
+field_type: entity_reference

--- a/config/default/core.base_field_override.media.image.name.yml
+++ b/config/default/core.base_field_override.media.image.name.yml
@@ -1,0 +1,20 @@
+uuid: bbfec62a-72fb-4271-8b72-f26051504154
+langcode: en
+status: true
+dependencies:
+  config:
+    - media_entity.bundle.image
+id: media.image.name
+field_name: name
+entity_type: media
+bundle: image
+label: 'Media name'
+description: 'The name of this media.'
+required: true
+translatable: false
+default_value:
+  -
+    value: ''
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/default/core.base_field_override.media.image.revision_log.yml
+++ b/config/default/core.base_field_override.media.image.revision_log.yml
@@ -1,0 +1,18 @@
+uuid: f5fc4d47-914c-4b84-bf61-99e4b082224f
+langcode: en
+status: true
+dependencies:
+  config:
+    - media_entity.bundle.image
+id: media.image.revision_log
+field_name: revision_log
+entity_type: media
+bundle: image
+label: 'Revision Log'
+description: 'The log entry explaining the changes in this revision.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string_long

--- a/config/default/core.base_field_override.media.image.status.yml
+++ b/config/default/core.base_field_override.media.image.status.yml
@@ -1,0 +1,22 @@
+uuid: 2599e2dd-d2de-455d-936e-9b60143cb196
+langcode: en
+status: true
+dependencies:
+  config:
+    - media_entity.bundle.image
+id: media.image.status
+field_name: status
+entity_type: media
+bundle: image
+label: 'Publishing status'
+description: 'A boolean indicating whether the media is published.'
+required: false
+translatable: false
+default_value:
+  -
+    value: 1
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/config/default/core.base_field_override.media.image.uid.yml
+++ b/config/default/core.base_field_override.media.image.uid.yml
@@ -1,0 +1,20 @@
+uuid: 1f6c8f45-aff4-4467-9f91-3a1fca746d9b
+langcode: en
+status: true
+dependencies:
+  config:
+    - media_entity.bundle.image
+id: media.image.uid
+field_name: uid
+entity_type: media
+bundle: image
+label: 'Publisher ID'
+description: 'The user ID of the media publisher.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: 'Drupal\media_entity\Entity\Media::getCurrentUserId'
+settings:
+  handler: default
+  handler_settings: {  }
+field_type: entity_reference

--- a/config/default/core.base_field_override.media.instagram.changed.yml
+++ b/config/default/core.base_field_override.media.instagram.changed.yml
@@ -1,0 +1,18 @@
+uuid: 51281a1e-6e13-45ab-b32d-d8c2be2a96f1
+langcode: en
+status: true
+dependencies:
+  config:
+    - media_entity.bundle.instagram
+id: media.instagram.changed
+field_name: changed
+entity_type: media
+bundle: instagram
+label: Changed
+description: 'The time that the media was last edited.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: changed

--- a/config/default/core.base_field_override.media.instagram.created.yml
+++ b/config/default/core.base_field_override.media.instagram.created.yml
@@ -1,0 +1,18 @@
+uuid: d86f01b7-bdfe-474b-a466-fb8210573923
+langcode: en
+status: true
+dependencies:
+  config:
+    - media_entity.bundle.instagram
+id: media.instagram.created
+field_name: created
+entity_type: media
+bundle: instagram
+label: Created
+description: 'The time that the media was created.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: created

--- a/config/default/core.base_field_override.media.instagram.moderation_state.yml
+++ b/config/default/core.base_field_override.media.instagram.moderation_state.yml
@@ -1,0 +1,20 @@
+uuid: 21b5a826-b32d-4681-887c-1ecfbdb2df79
+langcode: en
+status: true
+dependencies:
+  config:
+    - media_entity.bundle.instagram
+id: media.instagram.moderation_state
+field_name: moderation_state
+entity_type: media
+bundle: instagram
+label: 'Moderation state'
+description: 'The moderation state of this piece of content.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: default
+  handler_settings: {  }
+field_type: entity_reference

--- a/config/default/core.base_field_override.media.instagram.name.yml
+++ b/config/default/core.base_field_override.media.instagram.name.yml
@@ -1,0 +1,20 @@
+uuid: 3adb5f6e-dd12-4bba-9f2b-294e73dfa28d
+langcode: en
+status: true
+dependencies:
+  config:
+    - media_entity.bundle.instagram
+id: media.instagram.name
+field_name: name
+entity_type: media
+bundle: instagram
+label: 'Media name'
+description: 'The name of this media.'
+required: true
+translatable: false
+default_value:
+  -
+    value: ''
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/default/core.base_field_override.media.instagram.revision_log.yml
+++ b/config/default/core.base_field_override.media.instagram.revision_log.yml
@@ -1,0 +1,18 @@
+uuid: 77126cb8-ab29-43e2-801b-86f65cfabf4c
+langcode: en
+status: true
+dependencies:
+  config:
+    - media_entity.bundle.instagram
+id: media.instagram.revision_log
+field_name: revision_log
+entity_type: media
+bundle: instagram
+label: 'Revision Log'
+description: 'The log entry explaining the changes in this revision.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string_long

--- a/config/default/core.base_field_override.media.instagram.status.yml
+++ b/config/default/core.base_field_override.media.instagram.status.yml
@@ -1,0 +1,22 @@
+uuid: f69fcb70-b339-4dd2-b4c5-355aeebd2e3c
+langcode: en
+status: true
+dependencies:
+  config:
+    - media_entity.bundle.instagram
+id: media.instagram.status
+field_name: status
+entity_type: media
+bundle: instagram
+label: 'Publishing status'
+description: 'A boolean indicating whether the media is published.'
+required: false
+translatable: false
+default_value:
+  -
+    value: 1
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/config/default/core.base_field_override.media.instagram.uid.yml
+++ b/config/default/core.base_field_override.media.instagram.uid.yml
@@ -1,0 +1,20 @@
+uuid: e7dc6a27-559b-4a76-b6c1-745fd9a2a49b
+langcode: en
+status: true
+dependencies:
+  config:
+    - media_entity.bundle.instagram
+id: media.instagram.uid
+field_name: uid
+entity_type: media
+bundle: instagram
+label: 'Publisher ID'
+description: 'The user ID of the media publisher.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: 'Drupal\media_entity\Entity\Media::getCurrentUserId'
+settings:
+  handler: default
+  handler_settings: {  }
+field_type: entity_reference

--- a/config/default/core.base_field_override.media.tweet.changed.yml
+++ b/config/default/core.base_field_override.media.tweet.changed.yml
@@ -1,0 +1,18 @@
+uuid: de8a55ab-09e3-42d9-bf9b-4fa4bd4141eb
+langcode: en
+status: true
+dependencies:
+  config:
+    - media_entity.bundle.tweet
+id: media.tweet.changed
+field_name: changed
+entity_type: media
+bundle: tweet
+label: Changed
+description: 'The time that the media was last edited.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: changed

--- a/config/default/core.base_field_override.media.tweet.created.yml
+++ b/config/default/core.base_field_override.media.tweet.created.yml
@@ -1,0 +1,18 @@
+uuid: 9ef5cd27-ded2-48e8-8692-62051c822ee1
+langcode: en
+status: true
+dependencies:
+  config:
+    - media_entity.bundle.tweet
+id: media.tweet.created
+field_name: created
+entity_type: media
+bundle: tweet
+label: Created
+description: 'The time that the media was created.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: created

--- a/config/default/core.base_field_override.media.tweet.moderation_state.yml
+++ b/config/default/core.base_field_override.media.tweet.moderation_state.yml
@@ -1,0 +1,20 @@
+uuid: 0755830c-66f9-459a-876f-8d002cb2ff91
+langcode: en
+status: true
+dependencies:
+  config:
+    - media_entity.bundle.tweet
+id: media.tweet.moderation_state
+field_name: moderation_state
+entity_type: media
+bundle: tweet
+label: 'Moderation state'
+description: 'The moderation state of this piece of content.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: default
+  handler_settings: {  }
+field_type: entity_reference

--- a/config/default/core.base_field_override.media.tweet.name.yml
+++ b/config/default/core.base_field_override.media.tweet.name.yml
@@ -1,0 +1,20 @@
+uuid: 356739f9-bae2-425c-bbc4-c732dd39d3b0
+langcode: en
+status: true
+dependencies:
+  config:
+    - media_entity.bundle.tweet
+id: media.tweet.name
+field_name: name
+entity_type: media
+bundle: tweet
+label: 'Media name'
+description: 'The name of this media.'
+required: true
+translatable: false
+default_value:
+  -
+    value: ''
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/default/core.base_field_override.media.tweet.revision_log.yml
+++ b/config/default/core.base_field_override.media.tweet.revision_log.yml
@@ -1,0 +1,18 @@
+uuid: b617a419-e6c5-4328-99ba-9007936fbdf6
+langcode: en
+status: true
+dependencies:
+  config:
+    - media_entity.bundle.tweet
+id: media.tweet.revision_log
+field_name: revision_log
+entity_type: media
+bundle: tweet
+label: 'Revision Log'
+description: 'The log entry explaining the changes in this revision.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string_long

--- a/config/default/core.base_field_override.media.tweet.status.yml
+++ b/config/default/core.base_field_override.media.tweet.status.yml
@@ -1,0 +1,22 @@
+uuid: 5744e63c-9ad4-4c48-9a26-3492ea91449e
+langcode: en
+status: true
+dependencies:
+  config:
+    - media_entity.bundle.tweet
+id: media.tweet.status
+field_name: status
+entity_type: media
+bundle: tweet
+label: 'Publishing status'
+description: 'A boolean indicating whether the media is published.'
+required: false
+translatable: false
+default_value:
+  -
+    value: 1
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/config/default/core.base_field_override.media.tweet.uid.yml
+++ b/config/default/core.base_field_override.media.tweet.uid.yml
@@ -1,0 +1,20 @@
+uuid: 3d3cc84f-25ff-4d00-bdbc-9c12c1cd5fe1
+langcode: en
+status: true
+dependencies:
+  config:
+    - media_entity.bundle.tweet
+id: media.tweet.uid
+field_name: uid
+entity_type: media
+bundle: tweet
+label: 'Publisher ID'
+description: 'The user ID of the media publisher.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: 'Drupal\media_entity\Entity\Media::getCurrentUserId'
+settings:
+  handler: default
+  handler_settings: {  }
+field_type: entity_reference

--- a/config/default/core.base_field_override.media.video.changed.yml
+++ b/config/default/core.base_field_override.media.video.changed.yml
@@ -1,0 +1,18 @@
+uuid: 75b7de7d-2cee-42c6-9e9b-103a222dba99
+langcode: en
+status: true
+dependencies:
+  config:
+    - media_entity.bundle.video
+id: media.video.changed
+field_name: changed
+entity_type: media
+bundle: video
+label: Changed
+description: 'The time that the media was last edited.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: changed

--- a/config/default/core.base_field_override.media.video.created.yml
+++ b/config/default/core.base_field_override.media.video.created.yml
@@ -1,0 +1,18 @@
+uuid: c6c0a3fd-1798-4927-ab2f-12bba151ed54
+langcode: en
+status: true
+dependencies:
+  config:
+    - media_entity.bundle.video
+id: media.video.created
+field_name: created
+entity_type: media
+bundle: video
+label: Created
+description: 'The time that the media was created.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: created

--- a/config/default/core.base_field_override.media.video.moderation_state.yml
+++ b/config/default/core.base_field_override.media.video.moderation_state.yml
@@ -1,0 +1,20 @@
+uuid: d2d5781b-279b-4909-b7a1-103bb63a5112
+langcode: en
+status: true
+dependencies:
+  config:
+    - media_entity.bundle.video
+id: media.video.moderation_state
+field_name: moderation_state
+entity_type: media
+bundle: video
+label: 'Moderation state'
+description: 'The moderation state of this piece of content.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: default
+  handler_settings: {  }
+field_type: entity_reference

--- a/config/default/core.base_field_override.media.video.name.yml
+++ b/config/default/core.base_field_override.media.video.name.yml
@@ -1,0 +1,20 @@
+uuid: 5c8824bd-fda2-4b24-a815-47cd99aad48f
+langcode: en
+status: true
+dependencies:
+  config:
+    - media_entity.bundle.video
+id: media.video.name
+field_name: name
+entity_type: media
+bundle: video
+label: 'Media name'
+description: 'The name of this media.'
+required: true
+translatable: false
+default_value:
+  -
+    value: ''
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/default/core.base_field_override.media.video.revision_log.yml
+++ b/config/default/core.base_field_override.media.video.revision_log.yml
@@ -1,0 +1,18 @@
+uuid: 53b019d0-ca2b-4d20-bb43-80f9ed180199
+langcode: en
+status: true
+dependencies:
+  config:
+    - media_entity.bundle.video
+id: media.video.revision_log
+field_name: revision_log
+entity_type: media
+bundle: video
+label: 'Revision Log'
+description: 'The log entry explaining the changes in this revision.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string_long

--- a/config/default/core.base_field_override.media.video.status.yml
+++ b/config/default/core.base_field_override.media.video.status.yml
@@ -1,0 +1,22 @@
+uuid: 7cda79f9-3fc6-4104-8dff-8e2009f452c5
+langcode: en
+status: true
+dependencies:
+  config:
+    - media_entity.bundle.video
+id: media.video.status
+field_name: status
+entity_type: media
+bundle: video
+label: 'Publishing status'
+description: 'A boolean indicating whether the media is published.'
+required: false
+translatable: false
+default_value:
+  -
+    value: 1
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/config/default/core.base_field_override.media.video.uid.yml
+++ b/config/default/core.base_field_override.media.video.uid.yml
@@ -1,0 +1,20 @@
+uuid: 4e4c6786-4cb2-4816-b35f-c82a5b79439f
+langcode: en
+status: true
+dependencies:
+  config:
+    - media_entity.bundle.video
+id: media.video.uid
+field_name: uid
+entity_type: media
+bundle: video
+label: 'Publisher ID'
+description: 'The user ID of the media publisher.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: 'Drupal\media_entity\Entity\Media::getCurrentUserId'
+settings:
+  handler: default
+  handler_settings: {  }
+field_type: entity_reference

--- a/config/default/core.base_field_override.menu_link_content.menu_link_content.changed.yml
+++ b/config/default/core.base_field_override.menu_link_content.menu_link_content.changed.yml
@@ -1,0 +1,18 @@
+uuid: d18f08d7-c428-4c28-8106-1373be77f503
+langcode: en
+status: true
+dependencies:
+  module:
+    - menu_link_content
+id: menu_link_content.menu_link_content.changed
+field_name: changed
+entity_type: menu_link_content
+bundle: menu_link_content
+label: Changed
+description: 'The time that the menu link was last edited.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: changed

--- a/config/default/core.base_field_override.menu_link_content.menu_link_content.description.yml
+++ b/config/default/core.base_field_override.menu_link_content.menu_link_content.description.yml
@@ -1,0 +1,18 @@
+uuid: fd55a00b-4fa3-45f1-9367-e5a153e4ecfe
+langcode: en
+status: true
+dependencies:
+  module:
+    - menu_link_content
+id: menu_link_content.menu_link_content.description
+field_name: description
+entity_type: menu_link_content
+bundle: menu_link_content
+label: Description
+description: 'Shown when hovering over the menu link.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/default/core.base_field_override.menu_link_content.menu_link_content.title.yml
+++ b/config/default/core.base_field_override.menu_link_content.menu_link_content.title.yml
@@ -1,0 +1,18 @@
+uuid: ec55ee72-ef0c-4579-9038-a66683ea22da
+langcode: en
+status: true
+dependencies:
+  module:
+    - menu_link_content
+id: menu_link_content.menu_link_content.title
+field_name: title
+entity_type: menu_link_content
+bundle: menu_link_content
+label: 'Menu link title'
+description: 'The text to be used for this link in the menu.'
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/default/core.base_field_override.node.knowledge_base.changed.yml
+++ b/config/default/core.base_field_override.node.knowledge_base.changed.yml
@@ -1,0 +1,18 @@
+uuid: 0b440110-29d4-448d-a1ca-ea63eb594db6
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.knowledge_base
+id: node.knowledge_base.changed
+field_name: changed
+entity_type: node
+bundle: knowledge_base
+label: Changed
+description: 'The time that the node was last edited.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: changed

--- a/config/default/core.base_field_override.node.knowledge_base.created.yml
+++ b/config/default/core.base_field_override.node.knowledge_base.created.yml
@@ -1,0 +1,18 @@
+uuid: e1125cce-da75-4374-9ce5-0a16915bef93
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.knowledge_base
+id: node.knowledge_base.created
+field_name: created
+entity_type: node
+bundle: knowledge_base
+label: 'Authored on'
+description: 'The time that the node was created.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: created

--- a/config/default/core.base_field_override.node.knowledge_base.menu_link.yml
+++ b/config/default/core.base_field_override.node.knowledge_base.menu_link.yml
@@ -1,0 +1,20 @@
+uuid: f702bc70-29cd-4212-82d5-7b6657fdfbe0
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.knowledge_base
+id: node.knowledge_base.menu_link
+field_name: menu_link
+entity_type: node
+bundle: knowledge_base
+label: 'Menu link'
+description: 'Computed menu link for the node (only available during node saving).'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: default
+  handler_settings: {  }
+field_type: entity_reference

--- a/config/default/core.base_field_override.node.knowledge_base.moderation_state.yml
+++ b/config/default/core.base_field_override.node.knowledge_base.moderation_state.yml
@@ -1,0 +1,20 @@
+uuid: 2aaf903c-4c37-48a2-a769-6dfbcad3d7a8
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.knowledge_base
+id: node.knowledge_base.moderation_state
+field_name: moderation_state
+entity_type: node
+bundle: knowledge_base
+label: 'Moderation state'
+description: 'The moderation state of this piece of content.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: default
+  handler_settings: {  }
+field_type: entity_reference

--- a/config/default/core.base_field_override.node.knowledge_base.path.yml
+++ b/config/default/core.base_field_override.node.knowledge_base.path.yml
@@ -1,0 +1,20 @@
+uuid: fbd4513a-8fb3-4f31-b380-e2cfe4c7d2bb
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.knowledge_base
+  module:
+    - path
+id: node.knowledge_base.path
+field_name: path
+entity_type: node
+bundle: knowledge_base
+label: 'URL alias'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: path

--- a/config/default/core.base_field_override.node.knowledge_base.promote.yml
+++ b/config/default/core.base_field_override.node.knowledge_base.promote.yml
@@ -11,7 +11,7 @@ bundle: knowledge_base
 label: 'Promoted to front page'
 description: ''
 required: false
-translatable: true
+translatable: false
 default_value:
   -
     value: 0

--- a/config/default/core.base_field_override.node.knowledge_base.status.yml
+++ b/config/default/core.base_field_override.node.knowledge_base.status.yml
@@ -1,0 +1,22 @@
+uuid: 29b0c492-60a3-41fc-b443-f432fe4d2f67
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.knowledge_base
+id: node.knowledge_base.status
+field_name: status
+entity_type: node
+bundle: knowledge_base
+label: 'Publishing status'
+description: 'A boolean indicating the published state.'
+required: false
+translatable: false
+default_value:
+  -
+    value: 1
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/config/default/core.base_field_override.node.knowledge_base.sticky.yml
+++ b/config/default/core.base_field_override.node.knowledge_base.sticky.yml
@@ -1,0 +1,22 @@
+uuid: 39280d97-97de-43d0-87a8-5344c580ccbb
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.knowledge_base
+id: node.knowledge_base.sticky
+field_name: sticky
+entity_type: node
+bundle: knowledge_base
+label: 'Sticky at top of lists'
+description: ''
+required: false
+translatable: false
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/config/default/core.base_field_override.node.knowledge_base.title.yml
+++ b/config/default/core.base_field_override.node.knowledge_base.title.yml
@@ -1,0 +1,18 @@
+uuid: 65d372b1-2c61-4c45-a75a-6645a0f25570
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.knowledge_base
+id: node.knowledge_base.title
+field_name: title
+entity_type: node
+bundle: knowledge_base
+label: Title
+description: ''
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/default/core.base_field_override.node.knowledge_base.uid.yml
+++ b/config/default/core.base_field_override.node.knowledge_base.uid.yml
@@ -1,0 +1,20 @@
+uuid: fb937b92-f65b-4c75-b233-f030d379b523
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.knowledge_base
+id: node.knowledge_base.uid
+field_name: uid
+entity_type: node
+bundle: knowledge_base
+label: 'Authored by'
+description: 'The username of the content author.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: 'Drupal\node\Entity\Node::getCurrentUserId'
+settings:
+  handler: default
+  handler_settings: {  }
+field_type: entity_reference

--- a/config/default/core.base_field_override.node.landing_page.changed.yml
+++ b/config/default/core.base_field_override.node.landing_page.changed.yml
@@ -11,7 +11,7 @@ bundle: landing_page
 label: Changed
 description: 'The time that the node was last edited.'
 required: false
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings: {  }

--- a/config/default/core.base_field_override.node.landing_page.changed.yml
+++ b/config/default/core.base_field_override.node.landing_page.changed.yml
@@ -1,0 +1,18 @@
+uuid: 93abddcf-fdf2-48e4-a0b7-7c7fc330138f
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.landing_page
+id: node.landing_page.changed
+field_name: changed
+entity_type: node
+bundle: landing_page
+label: Changed
+description: 'The time that the node was last edited.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: changed

--- a/config/default/core.base_field_override.node.landing_page.created.yml
+++ b/config/default/core.base_field_override.node.landing_page.created.yml
@@ -11,7 +11,7 @@ bundle: landing_page
 label: 'Authored on'
 description: 'The time that the node was created.'
 required: false
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings: {  }

--- a/config/default/core.base_field_override.node.landing_page.created.yml
+++ b/config/default/core.base_field_override.node.landing_page.created.yml
@@ -1,0 +1,18 @@
+uuid: 5e3d7323-d509-48b8-a609-a5a166496589
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.landing_page
+id: node.landing_page.created
+field_name: created
+entity_type: node
+bundle: landing_page
+label: 'Authored on'
+description: 'The time that the node was created.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: created

--- a/config/default/core.base_field_override.node.landing_page.menu_link.yml
+++ b/config/default/core.base_field_override.node.landing_page.menu_link.yml
@@ -11,7 +11,7 @@ bundle: landing_page
 label: 'Menu link'
 description: 'Computed menu link for the node (only available during node saving).'
 required: false
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings:

--- a/config/default/core.base_field_override.node.landing_page.menu_link.yml
+++ b/config/default/core.base_field_override.node.landing_page.menu_link.yml
@@ -1,0 +1,20 @@
+uuid: 11e2b4db-db8e-428c-ac37-a5e86afefae0
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.landing_page
+id: node.landing_page.menu_link
+field_name: menu_link
+entity_type: node
+bundle: landing_page
+label: 'Menu link'
+description: 'Computed menu link for the node (only available during node saving).'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: default
+  handler_settings: {  }
+field_type: entity_reference

--- a/config/default/core.base_field_override.node.landing_page.moderation_state.yml
+++ b/config/default/core.base_field_override.node.landing_page.moderation_state.yml
@@ -11,7 +11,7 @@ bundle: landing_page
 label: 'Moderation state'
 description: 'The moderation state of this piece of content.'
 required: false
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings:

--- a/config/default/core.base_field_override.node.landing_page.moderation_state.yml
+++ b/config/default/core.base_field_override.node.landing_page.moderation_state.yml
@@ -1,0 +1,20 @@
+uuid: 989622ac-e8b4-4509-b60f-bea8ab645c25
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.landing_page
+id: node.landing_page.moderation_state
+field_name: moderation_state
+entity_type: node
+bundle: landing_page
+label: 'Moderation state'
+description: 'The moderation state of this piece of content.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: default
+  handler_settings: {  }
+field_type: entity_reference

--- a/config/default/core.base_field_override.node.landing_page.path.yml
+++ b/config/default/core.base_field_override.node.landing_page.path.yml
@@ -1,0 +1,20 @@
+uuid: 9e513ae6-dd39-448b-b54d-86a89cc253b9
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.landing_page
+  module:
+    - path
+id: node.landing_page.path
+field_name: path
+entity_type: node
+bundle: landing_page
+label: 'URL alias'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: path

--- a/config/default/core.base_field_override.node.landing_page.path.yml
+++ b/config/default/core.base_field_override.node.landing_page.path.yml
@@ -13,7 +13,7 @@ bundle: landing_page
 label: 'URL alias'
 description: ''
 required: false
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings: {  }

--- a/config/default/core.base_field_override.node.landing_page.promote.yml
+++ b/config/default/core.base_field_override.node.landing_page.promote.yml
@@ -13,7 +13,7 @@ bundle: landing_page
 label: 'Promoted to front page'
 description: ''
 required: false
-translatable: true
+translatable: false
 default_value:
   -
     value: 0

--- a/config/default/core.base_field_override.node.landing_page.promote.yml
+++ b/config/default/core.base_field_override.node.landing_page.promote.yml
@@ -13,7 +13,7 @@ bundle: landing_page
 label: 'Promoted to front page'
 description: ''
 required: false
-translatable: false
+translatable: true
 default_value:
   -
     value: 0

--- a/config/default/core.base_field_override.node.landing_page.status.yml
+++ b/config/default/core.base_field_override.node.landing_page.status.yml
@@ -1,0 +1,22 @@
+uuid: 99dc819a-0867-4751-986b-3ac695dd40d5
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.landing_page
+id: node.landing_page.status
+field_name: status
+entity_type: node
+bundle: landing_page
+label: 'Publishing status'
+description: 'A boolean indicating the published state.'
+required: false
+translatable: false
+default_value:
+  -
+    value: 1
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/config/default/core.base_field_override.node.landing_page.status.yml
+++ b/config/default/core.base_field_override.node.landing_page.status.yml
@@ -11,7 +11,7 @@ bundle: landing_page
 label: 'Publishing status'
 description: 'A boolean indicating the published state.'
 required: false
-translatable: false
+translatable: true
 default_value:
   -
     value: 1

--- a/config/default/core.base_field_override.node.landing_page.sticky.yml
+++ b/config/default/core.base_field_override.node.landing_page.sticky.yml
@@ -1,0 +1,22 @@
+uuid: d62de0a6-3e3a-49c8-905d-b8e73f0f6b10
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.landing_page
+id: node.landing_page.sticky
+field_name: sticky
+entity_type: node
+bundle: landing_page
+label: 'Sticky at top of lists'
+description: ''
+required: false
+translatable: false
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/config/default/core.base_field_override.node.landing_page.sticky.yml
+++ b/config/default/core.base_field_override.node.landing_page.sticky.yml
@@ -11,7 +11,7 @@ bundle: landing_page
 label: 'Sticky at top of lists'
 description: ''
 required: false
-translatable: false
+translatable: true
 default_value:
   -
     value: 0

--- a/config/default/core.base_field_override.node.landing_page.title.yml
+++ b/config/default/core.base_field_override.node.landing_page.title.yml
@@ -1,0 +1,18 @@
+uuid: b390c637-fbce-46b9-a690-11e460c3d893
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.landing_page
+id: node.landing_page.title
+field_name: title
+entity_type: node
+bundle: landing_page
+label: Title
+description: ''
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/default/core.base_field_override.node.landing_page.title.yml
+++ b/config/default/core.base_field_override.node.landing_page.title.yml
@@ -11,7 +11,7 @@ bundle: landing_page
 label: Title
 description: ''
 required: true
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings: {  }

--- a/config/default/core.base_field_override.node.landing_page.uid.yml
+++ b/config/default/core.base_field_override.node.landing_page.uid.yml
@@ -11,7 +11,7 @@ bundle: landing_page
 label: 'Authored by'
 description: 'The username of the content author.'
 required: false
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: 'Drupal\node\Entity\Node::getCurrentUserId'
 settings:

--- a/config/default/core.base_field_override.node.landing_page.uid.yml
+++ b/config/default/core.base_field_override.node.landing_page.uid.yml
@@ -1,0 +1,20 @@
+uuid: da6aae27-1930-40c3-aa6b-8d1028b495ec
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.landing_page
+id: node.landing_page.uid
+field_name: uid
+entity_type: node
+bundle: landing_page
+label: 'Authored by'
+description: 'The username of the content author.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: 'Drupal\node\Entity\Node::getCurrentUserId'
+settings:
+  handler: default
+  handler_settings: {  }
+field_type: entity_reference

--- a/config/default/core.base_field_override.node.news_article.changed.yml
+++ b/config/default/core.base_field_override.node.news_article.changed.yml
@@ -1,0 +1,18 @@
+uuid: 098ac912-548d-43cd-8282-2a32c0923174
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.news_article
+id: node.news_article.changed
+field_name: changed
+entity_type: node
+bundle: news_article
+label: Changed
+description: 'The time that the node was last edited.'
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: changed

--- a/config/default/core.base_field_override.node.news_article.created.yml
+++ b/config/default/core.base_field_override.node.news_article.created.yml
@@ -1,0 +1,18 @@
+uuid: 042d5726-5cdb-4da5-8ba9-18f82bf79bfb
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.news_article
+id: node.news_article.created
+field_name: created
+entity_type: node
+bundle: news_article
+label: 'Authored on'
+description: 'The time that the node was created.'
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: created

--- a/config/default/core.base_field_override.node.news_article.menu_link.yml
+++ b/config/default/core.base_field_override.node.news_article.menu_link.yml
@@ -1,0 +1,20 @@
+uuid: d71614c7-9e59-456f-b4d2-5dc81f351a4e
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.news_article
+id: node.news_article.menu_link
+field_name: menu_link
+entity_type: node
+bundle: news_article
+label: 'Menu link'
+description: 'Computed menu link for the node (only available during node saving).'
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: default
+  handler_settings: {  }
+field_type: entity_reference

--- a/config/default/core.base_field_override.node.news_article.moderation_state.yml
+++ b/config/default/core.base_field_override.node.news_article.moderation_state.yml
@@ -1,0 +1,20 @@
+uuid: c03db3ed-2f79-491b-b540-460a53551ec0
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.news_article
+id: node.news_article.moderation_state
+field_name: moderation_state
+entity_type: node
+bundle: news_article
+label: 'Moderation state'
+description: 'The moderation state of this piece of content.'
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: default
+  handler_settings: {  }
+field_type: entity_reference

--- a/config/default/core.base_field_override.node.news_article.path.yml
+++ b/config/default/core.base_field_override.node.news_article.path.yml
@@ -1,0 +1,20 @@
+uuid: 7a0bbee7-9e5e-463d-8856-13276f56ae6e
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.news_article
+  module:
+    - path
+id: node.news_article.path
+field_name: path
+entity_type: node
+bundle: news_article
+label: 'URL alias'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: path

--- a/config/default/core.base_field_override.node.news_article.status.yml
+++ b/config/default/core.base_field_override.node.news_article.status.yml
@@ -1,0 +1,22 @@
+uuid: e3f8be6c-7a21-4a2a-89c3-0ab14da7d34b
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.news_article
+id: node.news_article.status
+field_name: status
+entity_type: node
+bundle: news_article
+label: 'Publishing status'
+description: 'A boolean indicating the published state.'
+required: false
+translatable: true
+default_value:
+  -
+    value: 1
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/config/default/core.base_field_override.node.news_article.sticky.yml
+++ b/config/default/core.base_field_override.node.news_article.sticky.yml
@@ -1,0 +1,22 @@
+uuid: 93b0c647-db3f-4520-afd7-e521f69b0213
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.news_article
+id: node.news_article.sticky
+field_name: sticky
+entity_type: node
+bundle: news_article
+label: 'Sticky at top of lists'
+description: ''
+required: false
+translatable: true
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/config/default/core.base_field_override.node.news_article.title.yml
+++ b/config/default/core.base_field_override.node.news_article.title.yml
@@ -1,0 +1,18 @@
+uuid: 58460fb2-9652-4b05-ae88-6d5b4d6919b2
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.news_article
+id: node.news_article.title
+field_name: title
+entity_type: node
+bundle: news_article
+label: Title
+description: ''
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/default/core.base_field_override.node.news_article.uid.yml
+++ b/config/default/core.base_field_override.node.news_article.uid.yml
@@ -1,0 +1,20 @@
+uuid: 03057e99-d2ce-4179-b568-70ac4f6583c5
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.news_article
+id: node.news_article.uid
+field_name: uid
+entity_type: node
+bundle: news_article
+label: 'Authored by'
+description: 'The username of the content author.'
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: 'Drupal\node\Entity\Node::getCurrentUserId'
+settings:
+  handler: default
+  handler_settings: {  }
+field_type: entity_reference

--- a/config/default/core.base_field_override.node.page.changed.yml
+++ b/config/default/core.base_field_override.node.page.changed.yml
@@ -1,0 +1,18 @@
+uuid: 3ea4c566-c679-4da0-b9b9-97a77d0614cf
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.page
+id: node.page.changed
+field_name: changed
+entity_type: node
+bundle: page
+label: Changed
+description: 'The time that the node was last edited.'
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: changed

--- a/config/default/core.base_field_override.node.page.created.yml
+++ b/config/default/core.base_field_override.node.page.created.yml
@@ -1,0 +1,18 @@
+uuid: a4819af5-5a95-4df7-a4a3-1ff80b823375
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.page
+id: node.page.created
+field_name: created
+entity_type: node
+bundle: page
+label: 'Authored on'
+description: 'The time that the node was created.'
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: created

--- a/config/default/core.base_field_override.node.page.menu_link.yml
+++ b/config/default/core.base_field_override.node.page.menu_link.yml
@@ -1,0 +1,20 @@
+uuid: 0c7e5952-4ef5-4fdc-9e6a-e44171cc29d8
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.page
+id: node.page.menu_link
+field_name: menu_link
+entity_type: node
+bundle: page
+label: 'Menu link'
+description: 'Computed menu link for the node (only available during node saving).'
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: default
+  handler_settings: {  }
+field_type: entity_reference

--- a/config/default/core.base_field_override.node.page.moderation_state.yml
+++ b/config/default/core.base_field_override.node.page.moderation_state.yml
@@ -1,0 +1,20 @@
+uuid: 4c9e3e38-09cc-4e9c-8b9d-dbe1c54a1ead
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.page
+id: node.page.moderation_state
+field_name: moderation_state
+entity_type: node
+bundle: page
+label: 'Moderation state'
+description: 'The moderation state of this piece of content.'
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: default
+  handler_settings: {  }
+field_type: entity_reference

--- a/config/default/core.base_field_override.node.page.path.yml
+++ b/config/default/core.base_field_override.node.page.path.yml
@@ -1,0 +1,20 @@
+uuid: ee13b6f7-7bee-425f-b2f8-7c371e32fa3c
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.page
+  module:
+    - path
+id: node.page.path
+field_name: path
+entity_type: node
+bundle: page
+label: 'URL alias'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: path

--- a/config/default/core.base_field_override.node.page.sticky.yml
+++ b/config/default/core.base_field_override.node.page.sticky.yml
@@ -1,0 +1,22 @@
+uuid: 570ec423-f7cb-4da7-81ce-0c3ad0dd6ce0
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.page
+id: node.page.sticky
+field_name: sticky
+entity_type: node
+bundle: page
+label: 'Sticky at top of lists'
+description: ''
+required: false
+translatable: true
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/config/default/core.base_field_override.node.page.title.yml
+++ b/config/default/core.base_field_override.node.page.title.yml
@@ -1,0 +1,18 @@
+uuid: 1d9ff5b1-17fe-4c55-b0ed-eb3255100aa8
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.page
+id: node.page.title
+field_name: title
+entity_type: node
+bundle: page
+label: Title
+description: ''
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/default/core.base_field_override.node.page.uid.yml
+++ b/config/default/core.base_field_override.node.page.uid.yml
@@ -1,0 +1,20 @@
+uuid: b7a8a968-2765-4f4e-a08e-9f7382f6320e
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.page
+id: node.page.uid
+field_name: uid
+entity_type: node
+bundle: page
+label: 'Authored by'
+description: 'The username of the content author.'
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: 'Drupal\node\Entity\Node::getCurrentUserId'
+settings:
+  handler: default
+  handler_settings: {  }
+field_type: entity_reference

--- a/config/default/core.base_field_override.node.pricing_plan.changed.yml
+++ b/config/default/core.base_field_override.node.pricing_plan.changed.yml
@@ -1,0 +1,18 @@
+uuid: bc50b49c-b69d-46e9-b262-4c5fce6b15aa
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.pricing_plan
+id: node.pricing_plan.changed
+field_name: changed
+entity_type: node
+bundle: pricing_plan
+label: Changed
+description: 'The time that the node was last edited.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: changed

--- a/config/default/core.base_field_override.node.pricing_plan.created.yml
+++ b/config/default/core.base_field_override.node.pricing_plan.created.yml
@@ -1,0 +1,18 @@
+uuid: c006acac-69fc-438a-8c77-cefb15fc4556
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.pricing_plan
+id: node.pricing_plan.created
+field_name: created
+entity_type: node
+bundle: pricing_plan
+label: 'Authored on'
+description: 'The time that the node was created.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: created

--- a/config/default/core.base_field_override.node.pricing_plan.menu_link.yml
+++ b/config/default/core.base_field_override.node.pricing_plan.menu_link.yml
@@ -1,0 +1,20 @@
+uuid: d9a4d3eb-0aae-4e57-b926-612007e27c17
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.pricing_plan
+id: node.pricing_plan.menu_link
+field_name: menu_link
+entity_type: node
+bundle: pricing_plan
+label: 'Menu link'
+description: 'Computed menu link for the node (only available during node saving).'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: default
+  handler_settings: {  }
+field_type: entity_reference

--- a/config/default/core.base_field_override.node.pricing_plan.moderation_state.yml
+++ b/config/default/core.base_field_override.node.pricing_plan.moderation_state.yml
@@ -1,0 +1,20 @@
+uuid: 475ba53a-f935-4243-a083-caa7929eb1fe
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.pricing_plan
+id: node.pricing_plan.moderation_state
+field_name: moderation_state
+entity_type: node
+bundle: pricing_plan
+label: 'Moderation state'
+description: 'The moderation state of this piece of content.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: default
+  handler_settings: {  }
+field_type: entity_reference

--- a/config/default/core.base_field_override.node.pricing_plan.path.yml
+++ b/config/default/core.base_field_override.node.pricing_plan.path.yml
@@ -1,0 +1,20 @@
+uuid: 6041cfbf-09f4-4de8-b16b-146fa72cf398
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.pricing_plan
+  module:
+    - path
+id: node.pricing_plan.path
+field_name: path
+entity_type: node
+bundle: pricing_plan
+label: 'URL alias'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: path

--- a/config/default/core.base_field_override.node.pricing_plan.promote.yml
+++ b/config/default/core.base_field_override.node.pricing_plan.promote.yml
@@ -11,7 +11,7 @@ bundle: pricing_plan
 label: 'Promoted to front page'
 description: ''
 required: false
-translatable: true
+translatable: false
 default_value:
   -
     value: 0

--- a/config/default/core.base_field_override.node.pricing_plan.status.yml
+++ b/config/default/core.base_field_override.node.pricing_plan.status.yml
@@ -1,0 +1,22 @@
+uuid: 55b9f562-8a40-4ffc-bceb-e11292275f25
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.pricing_plan
+id: node.pricing_plan.status
+field_name: status
+entity_type: node
+bundle: pricing_plan
+label: 'Publishing status'
+description: 'A boolean indicating the published state.'
+required: false
+translatable: false
+default_value:
+  -
+    value: 1
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/config/default/core.base_field_override.node.pricing_plan.sticky.yml
+++ b/config/default/core.base_field_override.node.pricing_plan.sticky.yml
@@ -1,0 +1,22 @@
+uuid: d17c553f-6706-474b-a667-a2525f6f24cd
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.pricing_plan
+id: node.pricing_plan.sticky
+field_name: sticky
+entity_type: node
+bundle: pricing_plan
+label: 'Sticky at top of lists'
+description: ''
+required: false
+translatable: false
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/config/default/core.base_field_override.node.pricing_plan.title.yml
+++ b/config/default/core.base_field_override.node.pricing_plan.title.yml
@@ -1,0 +1,18 @@
+uuid: 61bb7f8f-01df-4f83-8176-2af70eb3908c
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.pricing_plan
+id: node.pricing_plan.title
+field_name: title
+entity_type: node
+bundle: pricing_plan
+label: Title
+description: ''
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/default/core.base_field_override.node.pricing_plan.uid.yml
+++ b/config/default/core.base_field_override.node.pricing_plan.uid.yml
@@ -1,0 +1,20 @@
+uuid: 78aa53d3-fbc6-48f8-b723-e78c9e5198c0
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.pricing_plan
+id: node.pricing_plan.uid
+field_name: uid
+entity_type: node
+bundle: pricing_plan
+label: 'Authored by'
+description: 'The username of the content author.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: 'Drupal\node\Entity\Node::getCurrentUserId'
+settings:
+  handler: default
+  handler_settings: {  }
+field_type: entity_reference

--- a/config/default/core.base_field_override.node.site.changed.yml
+++ b/config/default/core.base_field_override.node.site.changed.yml
@@ -1,0 +1,18 @@
+uuid: d547f515-92ab-48b7-b0e2-5e82f2edf1a8
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.site
+id: node.site.changed
+field_name: changed
+entity_type: node
+bundle: site
+label: Changed
+description: 'The time that the node was last edited.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: changed

--- a/config/default/core.base_field_override.node.site.created.yml
+++ b/config/default/core.base_field_override.node.site.created.yml
@@ -1,0 +1,18 @@
+uuid: a30a22a6-2970-4240-beb4-18b8b37956e0
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.site
+id: node.site.created
+field_name: created
+entity_type: node
+bundle: site
+label: 'Authored on'
+description: 'The time that the node was created.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: created

--- a/config/default/core.base_field_override.node.site.menu_link.yml
+++ b/config/default/core.base_field_override.node.site.menu_link.yml
@@ -1,0 +1,20 @@
+uuid: 343cb2c7-6bcb-4b18-acac-73f48f62fa07
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.site
+id: node.site.menu_link
+field_name: menu_link
+entity_type: node
+bundle: site
+label: 'Menu link'
+description: 'Computed menu link for the node (only available during node saving).'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: default
+  handler_settings: {  }
+field_type: entity_reference

--- a/config/default/core.base_field_override.node.site.moderation_state.yml
+++ b/config/default/core.base_field_override.node.site.moderation_state.yml
@@ -1,0 +1,20 @@
+uuid: 4f1b0720-66c0-419f-bcd7-c5f62952c9a7
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.site
+id: node.site.moderation_state
+field_name: moderation_state
+entity_type: node
+bundle: site
+label: 'Moderation state'
+description: 'The moderation state of this piece of content.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: default
+  handler_settings: {  }
+field_type: entity_reference

--- a/config/default/core.base_field_override.node.site.path.yml
+++ b/config/default/core.base_field_override.node.site.path.yml
@@ -1,0 +1,20 @@
+uuid: 1b816f72-2e58-49db-b4db-7ed0b4ee963e
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.site
+  module:
+    - path
+id: node.site.path
+field_name: path
+entity_type: node
+bundle: site
+label: 'URL alias'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: path

--- a/config/default/core.base_field_override.node.site.promote.yml
+++ b/config/default/core.base_field_override.node.site.promote.yml
@@ -11,7 +11,7 @@ bundle: site
 label: 'Promoted to front page'
 description: ''
 required: false
-translatable: true
+translatable: false
 default_value:
   -
     value: 0

--- a/config/default/core.base_field_override.node.site.status.yml
+++ b/config/default/core.base_field_override.node.site.status.yml
@@ -1,0 +1,22 @@
+uuid: 760ee7cb-8f3a-4ad6-8832-0ab0f08e0b49
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.site
+id: node.site.status
+field_name: status
+entity_type: node
+bundle: site
+label: 'Publishing status'
+description: 'A boolean indicating the published state.'
+required: false
+translatable: false
+default_value:
+  -
+    value: 1
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/config/default/core.base_field_override.node.site.sticky.yml
+++ b/config/default/core.base_field_override.node.site.sticky.yml
@@ -1,0 +1,22 @@
+uuid: d4e7eca7-0e2c-4c48-a88a-44d68beb7ea8
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.site
+id: node.site.sticky
+field_name: sticky
+entity_type: node
+bundle: site
+label: 'Sticky at top of lists'
+description: ''
+required: false
+translatable: false
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/config/default/core.base_field_override.node.site.title.yml
+++ b/config/default/core.base_field_override.node.site.title.yml
@@ -11,7 +11,7 @@ bundle: site
 label: Name
 description: ''
 required: true
-translatable: true
+translatable: false
 default_value: {  }
 default_value_callback: ''
 settings: {  }

--- a/config/default/core.base_field_override.node.site.uid.yml
+++ b/config/default/core.base_field_override.node.site.uid.yml
@@ -1,0 +1,20 @@
+uuid: 4b9887e2-8e8b-4a2d-9d2a-288d89d34326
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.site
+id: node.site.uid
+field_name: uid
+entity_type: node
+bundle: site
+label: 'Authored by'
+description: 'The username of the content author.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: 'Drupal\node\Entity\Node::getCurrentUserId'
+settings:
+  handler: default
+  handler_settings: {  }
+field_type: entity_reference

--- a/config/default/core.base_field_override.node.testimonial.changed.yml
+++ b/config/default/core.base_field_override.node.testimonial.changed.yml
@@ -1,0 +1,18 @@
+uuid: 7213c1ec-e93e-4488-aeca-0ccaa5f9bcd8
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.testimonial
+id: node.testimonial.changed
+field_name: changed
+entity_type: node
+bundle: testimonial
+label: Changed
+description: 'The time that the node was last edited.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: changed

--- a/config/default/core.base_field_override.node.testimonial.created.yml
+++ b/config/default/core.base_field_override.node.testimonial.created.yml
@@ -1,0 +1,18 @@
+uuid: faa54228-18ad-49a2-90e5-5a630b8cd609
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.testimonial
+id: node.testimonial.created
+field_name: created
+entity_type: node
+bundle: testimonial
+label: 'Authored on'
+description: 'The time that the node was created.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: created

--- a/config/default/core.base_field_override.node.testimonial.menu_link.yml
+++ b/config/default/core.base_field_override.node.testimonial.menu_link.yml
@@ -1,0 +1,20 @@
+uuid: e07c4e48-b006-4f1b-8da7-37c199734857
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.testimonial
+id: node.testimonial.menu_link
+field_name: menu_link
+entity_type: node
+bundle: testimonial
+label: 'Menu link'
+description: 'Computed menu link for the node (only available during node saving).'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: default
+  handler_settings: {  }
+field_type: entity_reference

--- a/config/default/core.base_field_override.node.testimonial.moderation_state.yml
+++ b/config/default/core.base_field_override.node.testimonial.moderation_state.yml
@@ -1,0 +1,20 @@
+uuid: 92a0f99e-0cf7-4626-86e0-5d72bc329ea0
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.testimonial
+id: node.testimonial.moderation_state
+field_name: moderation_state
+entity_type: node
+bundle: testimonial
+label: 'Moderation state'
+description: 'The moderation state of this piece of content.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: default
+  handler_settings: {  }
+field_type: entity_reference

--- a/config/default/core.base_field_override.node.testimonial.path.yml
+++ b/config/default/core.base_field_override.node.testimonial.path.yml
@@ -1,0 +1,20 @@
+uuid: faef2ed4-0255-4e97-9f3c-2e5c3e12655d
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.testimonial
+  module:
+    - path
+id: node.testimonial.path
+field_name: path
+entity_type: node
+bundle: testimonial
+label: 'URL alias'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: path

--- a/config/default/core.base_field_override.node.testimonial.promote.yml
+++ b/config/default/core.base_field_override.node.testimonial.promote.yml
@@ -11,7 +11,7 @@ bundle: testimonial
 label: 'Promoted to front page'
 description: ''
 required: false
-translatable: true
+translatable: false
 default_value:
   -
     value: 0

--- a/config/default/core.base_field_override.node.testimonial.status.yml
+++ b/config/default/core.base_field_override.node.testimonial.status.yml
@@ -1,0 +1,22 @@
+uuid: 680cd410-172d-4737-9069-c698d424f319
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.testimonial
+id: node.testimonial.status
+field_name: status
+entity_type: node
+bundle: testimonial
+label: 'Publishing status'
+description: 'A boolean indicating the published state.'
+required: false
+translatable: false
+default_value:
+  -
+    value: 1
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/config/default/core.base_field_override.node.testimonial.sticky.yml
+++ b/config/default/core.base_field_override.node.testimonial.sticky.yml
@@ -1,0 +1,22 @@
+uuid: 0234cead-4ab4-4251-8b32-02303ede673a
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.testimonial
+id: node.testimonial.sticky
+field_name: sticky
+entity_type: node
+bundle: testimonial
+label: 'Sticky at top of lists'
+description: ''
+required: false
+translatable: false
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/config/default/core.base_field_override.node.testimonial.title.yml
+++ b/config/default/core.base_field_override.node.testimonial.title.yml
@@ -11,7 +11,7 @@ bundle: testimonial
 label: Name
 description: ''
 required: true
-translatable: true
+translatable: false
 default_value: {  }
 default_value_callback: ''
 settings: {  }

--- a/config/default/core.base_field_override.node.testimonial.uid.yml
+++ b/config/default/core.base_field_override.node.testimonial.uid.yml
@@ -1,0 +1,20 @@
+uuid: 65c3b353-1866-4824-8dc2-ca23c98695b2
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.testimonial
+id: node.testimonial.uid
+field_name: uid
+entity_type: node
+bundle: testimonial
+label: 'Authored by'
+description: 'The username of the content author.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: 'Drupal\node\Entity\Node::getCurrentUserId'
+settings:
+  handler: default
+  handler_settings: {  }
+field_type: entity_reference

--- a/config/default/core.base_field_override.shortcut.default.title.yml
+++ b/config/default/core.base_field_override.shortcut.default.title.yml
@@ -1,0 +1,18 @@
+uuid: 375fbc0c-0fa8-4d64-af08-70b9e8ce73c4
+langcode: en
+status: true
+dependencies:
+  config:
+    - shortcut.set.default
+id: shortcut.default.title
+field_name: title
+entity_type: shortcut
+bundle: default
+label: Name
+description: 'The name of the shortcut.'
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/default/core.base_field_override.taxonomy_term.agency.changed.yml
+++ b/config/default/core.base_field_override.taxonomy_term.agency.changed.yml
@@ -1,0 +1,18 @@
+uuid: cc6d3bb7-da37-4681-b3c6-f68b37b242b3
+langcode: en
+status: true
+dependencies:
+  config:
+    - taxonomy.vocabulary.agency
+id: taxonomy_term.agency.changed
+field_name: changed
+entity_type: taxonomy_term
+bundle: agency
+label: Changed
+description: 'The time that the term was last edited.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: changed

--- a/config/default/core.base_field_override.taxonomy_term.agency.changed.yml
+++ b/config/default/core.base_field_override.taxonomy_term.agency.changed.yml
@@ -11,7 +11,7 @@ bundle: agency
 label: Changed
 description: 'The time that the term was last edited.'
 required: false
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings: {  }

--- a/config/default/core.base_field_override.taxonomy_term.agency.description.yml
+++ b/config/default/core.base_field_override.taxonomy_term.agency.description.yml
@@ -1,0 +1,20 @@
+uuid: ab57254f-63a9-4af2-b158-72053ac048a7
+langcode: en
+status: true
+dependencies:
+  config:
+    - taxonomy.vocabulary.agency
+  module:
+    - text
+id: taxonomy_term.agency.description
+field_name: description
+entity_type: taxonomy_term
+bundle: agency
+label: Description
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: text_long

--- a/config/default/core.base_field_override.taxonomy_term.agency.description.yml
+++ b/config/default/core.base_field_override.taxonomy_term.agency.description.yml
@@ -13,7 +13,7 @@ bundle: agency
 label: Description
 description: ''
 required: false
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings: {  }

--- a/config/default/core.base_field_override.taxonomy_term.agency.name.yml
+++ b/config/default/core.base_field_override.taxonomy_term.agency.name.yml
@@ -11,7 +11,7 @@ bundle: agency
 label: Name
 description: ''
 required: true
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings: {  }

--- a/config/default/core.base_field_override.taxonomy_term.agency.name.yml
+++ b/config/default/core.base_field_override.taxonomy_term.agency.name.yml
@@ -1,0 +1,18 @@
+uuid: 0f99ad46-c7dd-4e3f-8318-b7f3b10ada56
+langcode: en
+status: true
+dependencies:
+  config:
+    - taxonomy.vocabulary.agency
+id: taxonomy_term.agency.name
+field_name: name
+entity_type: taxonomy_term
+bundle: agency
+label: Name
+description: ''
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/default/core.base_field_override.taxonomy_term.agency.path.yml
+++ b/config/default/core.base_field_override.taxonomy_term.agency.path.yml
@@ -1,0 +1,20 @@
+uuid: 2455e091-096f-4a10-9104-07330ddcdac3
+langcode: en
+status: true
+dependencies:
+  config:
+    - taxonomy.vocabulary.agency
+  module:
+    - path
+id: taxonomy_term.agency.path
+field_name: path
+entity_type: taxonomy_term
+bundle: agency
+label: 'URL alias'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: path

--- a/config/default/core.base_field_override.taxonomy_term.agency.path.yml
+++ b/config/default/core.base_field_override.taxonomy_term.agency.path.yml
@@ -13,7 +13,7 @@ bundle: agency
 label: 'URL alias'
 description: ''
 required: false
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings: {  }

--- a/config/default/core.base_field_override.taxonomy_term.environment.changed.yml
+++ b/config/default/core.base_field_override.taxonomy_term.environment.changed.yml
@@ -1,0 +1,18 @@
+uuid: 46578603-510a-4f45-a601-cde3711c209f
+langcode: en
+status: true
+dependencies:
+  config:
+    - taxonomy.vocabulary.environment
+id: taxonomy_term.environment.changed
+field_name: changed
+entity_type: taxonomy_term
+bundle: environment
+label: Changed
+description: 'The time that the term was last edited.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: changed

--- a/config/default/core.base_field_override.taxonomy_term.environment.description.yml
+++ b/config/default/core.base_field_override.taxonomy_term.environment.description.yml
@@ -1,0 +1,20 @@
+uuid: 5cdc2df1-62f0-4e03-bdcd-fc69f26da707
+langcode: en
+status: true
+dependencies:
+  config:
+    - taxonomy.vocabulary.environment
+  module:
+    - text
+id: taxonomy_term.environment.description
+field_name: description
+entity_type: taxonomy_term
+bundle: environment
+label: Description
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: text_long

--- a/config/default/core.base_field_override.taxonomy_term.environment.name.yml
+++ b/config/default/core.base_field_override.taxonomy_term.environment.name.yml
@@ -1,0 +1,18 @@
+uuid: ae6668b9-312a-4eff-87b0-63c81a3f5445
+langcode: en
+status: true
+dependencies:
+  config:
+    - taxonomy.vocabulary.environment
+id: taxonomy_term.environment.name
+field_name: name
+entity_type: taxonomy_term
+bundle: environment
+label: Name
+description: ''
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/default/core.base_field_override.taxonomy_term.environment.path.yml
+++ b/config/default/core.base_field_override.taxonomy_term.environment.path.yml
@@ -1,0 +1,20 @@
+uuid: 23ddee83-7781-4760-ab43-465c4416eb33
+langcode: en
+status: true
+dependencies:
+  config:
+    - taxonomy.vocabulary.environment
+  module:
+    - path
+id: taxonomy_term.environment.path
+field_name: path
+entity_type: taxonomy_term
+bundle: environment
+label: 'URL alias'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: path

--- a/config/default/core.base_field_override.taxonomy_term.knowledge_base.changed.yml
+++ b/config/default/core.base_field_override.taxonomy_term.knowledge_base.changed.yml
@@ -1,0 +1,18 @@
+uuid: 48c50122-d7f7-43ec-86da-b4c0501c4af3
+langcode: en
+status: true
+dependencies:
+  config:
+    - taxonomy.vocabulary.knowledge_base
+id: taxonomy_term.knowledge_base.changed
+field_name: changed
+entity_type: taxonomy_term
+bundle: knowledge_base
+label: Changed
+description: 'The time that the term was last edited.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: changed

--- a/config/default/core.base_field_override.taxonomy_term.knowledge_base.description.yml
+++ b/config/default/core.base_field_override.taxonomy_term.knowledge_base.description.yml
@@ -1,0 +1,20 @@
+uuid: 36b8747f-59cf-4488-b2fb-14311282a28f
+langcode: en
+status: true
+dependencies:
+  config:
+    - taxonomy.vocabulary.knowledge_base
+  module:
+    - text
+id: taxonomy_term.knowledge_base.description
+field_name: description
+entity_type: taxonomy_term
+bundle: knowledge_base
+label: Description
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: text_long

--- a/config/default/core.base_field_override.taxonomy_term.knowledge_base.name.yml
+++ b/config/default/core.base_field_override.taxonomy_term.knowledge_base.name.yml
@@ -1,0 +1,18 @@
+uuid: 6e2d45b5-d5dc-43e2-8d7f-1b3d8833f3c8
+langcode: en
+status: true
+dependencies:
+  config:
+    - taxonomy.vocabulary.knowledge_base
+id: taxonomy_term.knowledge_base.name
+field_name: name
+entity_type: taxonomy_term
+bundle: knowledge_base
+label: Name
+description: ''
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/default/core.base_field_override.taxonomy_term.knowledge_base.path.yml
+++ b/config/default/core.base_field_override.taxonomy_term.knowledge_base.path.yml
@@ -1,0 +1,20 @@
+uuid: df7174bf-bd7b-4e62-b620-e42f06039d3b
+langcode: en
+status: true
+dependencies:
+  config:
+    - taxonomy.vocabulary.knowledge_base
+  module:
+    - path
+id: taxonomy_term.knowledge_base.path
+field_name: path
+entity_type: taxonomy_term
+bundle: knowledge_base
+label: 'URL alias'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: path

--- a/config/default/core.base_field_override.taxonomy_term.status.changed.yml
+++ b/config/default/core.base_field_override.taxonomy_term.status.changed.yml
@@ -1,0 +1,18 @@
+uuid: 203839f1-2d5d-4078-ad1a-52915eb90950
+langcode: en
+status: true
+dependencies:
+  config:
+    - taxonomy.vocabulary.status
+id: taxonomy_term.status.changed
+field_name: changed
+entity_type: taxonomy_term
+bundle: status
+label: Changed
+description: 'The time that the term was last edited.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: changed

--- a/config/default/core.base_field_override.taxonomy_term.status.description.yml
+++ b/config/default/core.base_field_override.taxonomy_term.status.description.yml
@@ -1,0 +1,20 @@
+uuid: a86a6e27-23d5-4b1f-b934-8146a8ed5bb4
+langcode: en
+status: true
+dependencies:
+  config:
+    - taxonomy.vocabulary.status
+  module:
+    - text
+id: taxonomy_term.status.description
+field_name: description
+entity_type: taxonomy_term
+bundle: status
+label: Description
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: text_long

--- a/config/default/core.base_field_override.taxonomy_term.status.name.yml
+++ b/config/default/core.base_field_override.taxonomy_term.status.name.yml
@@ -1,0 +1,18 @@
+uuid: c219df6b-ad56-4175-a8df-45011bbe68a4
+langcode: en
+status: true
+dependencies:
+  config:
+    - taxonomy.vocabulary.status
+id: taxonomy_term.status.name
+field_name: name
+entity_type: taxonomy_term
+bundle: status
+label: Name
+description: ''
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/default/core.base_field_override.taxonomy_term.status.path.yml
+++ b/config/default/core.base_field_override.taxonomy_term.status.path.yml
@@ -1,0 +1,20 @@
+uuid: 1290473b-c5c7-4a2f-9422-ba45644f637c
+langcode: en
+status: true
+dependencies:
+  config:
+    - taxonomy.vocabulary.status
+  module:
+    - path
+id: taxonomy_term.status.path
+field_name: path
+entity_type: taxonomy_term
+bundle: status
+label: 'URL alias'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: path

--- a/config/default/core.base_field_override.taxonomy_term.tags.changed.yml
+++ b/config/default/core.base_field_override.taxonomy_term.tags.changed.yml
@@ -1,0 +1,18 @@
+uuid: 1877a911-a499-4223-80cf-4703f3afeb35
+langcode: en
+status: true
+dependencies:
+  config:
+    - taxonomy.vocabulary.tags
+id: taxonomy_term.tags.changed
+field_name: changed
+entity_type: taxonomy_term
+bundle: tags
+label: Changed
+description: 'The time that the term was last edited.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: changed

--- a/config/default/core.base_field_override.taxonomy_term.tags.description.yml
+++ b/config/default/core.base_field_override.taxonomy_term.tags.description.yml
@@ -1,0 +1,20 @@
+uuid: 4b9d3676-ea43-4024-a330-d6392b060cb8
+langcode: en
+status: true
+dependencies:
+  config:
+    - taxonomy.vocabulary.tags
+  module:
+    - text
+id: taxonomy_term.tags.description
+field_name: description
+entity_type: taxonomy_term
+bundle: tags
+label: Description
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: text_long

--- a/config/default/core.base_field_override.taxonomy_term.tags.name.yml
+++ b/config/default/core.base_field_override.taxonomy_term.tags.name.yml
@@ -1,0 +1,18 @@
+uuid: 84cba27c-4c10-4ee4-ba37-5f3caebf97c0
+langcode: en
+status: true
+dependencies:
+  config:
+    - taxonomy.vocabulary.tags
+id: taxonomy_term.tags.name
+field_name: name
+entity_type: taxonomy_term
+bundle: tags
+label: Name
+description: ''
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/default/core.base_field_override.taxonomy_term.tags.path.yml
+++ b/config/default/core.base_field_override.taxonomy_term.tags.path.yml
@@ -1,0 +1,20 @@
+uuid: 64ab47fa-a169-40a9-92b4-fc8f155dd97d
+langcode: en
+status: true
+dependencies:
+  config:
+    - taxonomy.vocabulary.tags
+  module:
+    - path
+id: taxonomy_term.tags.path
+field_name: path
+entity_type: taxonomy_term
+bundle: tags
+label: 'URL alias'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: path

--- a/config/default/core.base_field_override.user.user.changed.yml
+++ b/config/default/core.base_field_override.user.user.changed.yml
@@ -1,0 +1,18 @@
+uuid: deac3d90-9dd0-4075-8083-9b4a458f452e
+langcode: en
+status: true
+dependencies:
+  module:
+    - user
+id: user.user.changed
+field_name: changed
+entity_type: user
+bundle: user
+label: Changed
+description: 'The time that the user was last edited.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: changed

--- a/config/default/core.base_field_override.user.user.path.yml
+++ b/config/default/core.base_field_override.user.user.path.yml
@@ -1,0 +1,19 @@
+uuid: 629aff70-8f20-4aea-9706-eb03b35d94b9
+langcode: en
+status: true
+dependencies:
+  module:
+    - path
+    - user
+id: user.user.path
+field_name: path
+entity_type: user
+bundle: user
+label: 'URL alias'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: path

--- a/config/default/core.entity_form_display.block_content.basic.default.yml
+++ b/config/default/core.entity_form_display.block_content.basic.default.yml
@@ -32,4 +32,10 @@ content:
       placeholder: ''
     third_party_settings: {  }
     region: content
+  langcode:
+    type: language_select
+    weight: 2
+    region: content
+    settings: {  }
+    third_party_settings: {  }
 hidden: {  }

--- a/config/default/core.entity_form_display.block_content.block_with_background.default.yml
+++ b/config/default/core.entity_form_display.block_content.block_with_background.default.yml
@@ -44,4 +44,10 @@ content:
       size: 60
       placeholder: ''
     third_party_settings: {  }
+  langcode:
+    type: language_select
+    weight: 2
+    region: content
+    settings: {  }
+    third_party_settings: {  }
 hidden: {  }

--- a/config/default/core.entity_form_display.contact_message.apply_for_a_siteno.default.yml
+++ b/config/default/core.entity_form_display.contact_message.apply_for_a_siteno.default.yml
@@ -79,6 +79,12 @@ content:
     third_party_settings: {  }
     type: string_textarea
     region: content
+  langcode:
+    type: language_select
+    weight: 2
+    region: content
+    settings: {  }
+    third_party_settings: {  }
 hidden:
   copy: true
   mail: true

--- a/config/default/core.entity_form_display.media.document.default.yml
+++ b/config/default/core.entity_form_display.media.document.default.yml
@@ -30,6 +30,12 @@ content:
     weight: 3
     third_party_settings: {  }
     region: content
+  langcode:
+    type: language_select
+    weight: 2
+    region: content
+    settings: {  }
+    third_party_settings: {  }
   name:
     type: string_textfield
     weight: 2

--- a/config/default/core.entity_form_display.media.document.media_browser.yml
+++ b/config/default/core.entity_form_display.media.document.media_browser.yml
@@ -23,6 +23,12 @@ content:
     weight: 1
     third_party_settings: {  }
     region: content
+  langcode:
+    type: language_select
+    weight: 2
+    region: content
+    settings: {  }
+    third_party_settings: {  }
   name:
     type: string_textfield
     weight: 0

--- a/config/default/core.entity_form_display.media.image.default.yml
+++ b/config/default/core.entity_form_display.media.image.default.yml
@@ -32,6 +32,12 @@ content:
       preview_image_style: thumbnail
     third_party_settings: {  }
     region: content
+  langcode:
+    type: language_select
+    weight: 2
+    region: content
+    settings: {  }
+    third_party_settings: {  }
   name:
     type: string_textfield
     weight: 3

--- a/config/default/core.entity_form_display.media.image.media_browser.yml
+++ b/config/default/core.entity_form_display.media.image.media_browser.yml
@@ -33,6 +33,12 @@ content:
       progress_indicator: throbber
     third_party_settings: {  }
     region: content
+  langcode:
+    type: language_select
+    weight: 2
+    region: content
+    settings: {  }
+    third_party_settings: {  }
   name:
     type: string_textfield
     weight: 3

--- a/config/default/core.entity_form_display.media.instagram.default.yml
+++ b/config/default/core.entity_form_display.media.instagram.default.yml
@@ -30,6 +30,12 @@ content:
       display_label: true
     third_party_settings: {  }
     region: content
+  langcode:
+    type: language_select
+    weight: 2
+    region: content
+    settings: {  }
+    third_party_settings: {  }
   name:
     type: string_textfield
     weight: 0

--- a/config/default/core.entity_form_display.media.instagram.media_browser.yml
+++ b/config/default/core.entity_form_display.media.instagram.media_browser.yml
@@ -23,6 +23,12 @@ content:
       display_label: true
     third_party_settings: {  }
     region: content
+  langcode:
+    type: language_select
+    weight: 2
+    region: content
+    settings: {  }
+    third_party_settings: {  }
   name:
     type: string_textfield
     weight: 0

--- a/config/default/core.entity_form_display.media.tweet.default.yml
+++ b/config/default/core.entity_form_display.media.tweet.default.yml
@@ -30,6 +30,12 @@ content:
       display_label: true
     third_party_settings: {  }
     region: content
+  langcode:
+    type: language_select
+    weight: 2
+    region: content
+    settings: {  }
+    third_party_settings: {  }
   name:
     type: string_textfield
     weight: 0

--- a/config/default/core.entity_form_display.media.tweet.media_browser.yml
+++ b/config/default/core.entity_form_display.media.tweet.media_browser.yml
@@ -23,6 +23,12 @@ content:
       display_label: true
     third_party_settings: {  }
     region: content
+  langcode:
+    type: language_select
+    weight: 2
+    region: content
+    settings: {  }
+    third_party_settings: {  }
   name:
     type: string_textfield
     weight: 0

--- a/config/default/core.entity_form_display.media.video.default.yml
+++ b/config/default/core.entity_form_display.media.video.default.yml
@@ -29,6 +29,12 @@ content:
     settings: {  }
     third_party_settings: {  }
     region: content
+  langcode:
+    type: language_select
+    weight: 2
+    region: content
+    settings: {  }
+    third_party_settings: {  }
   name:
     type: string_textfield
     weight: 0

--- a/config/default/core.entity_form_display.media.video.media_browser.yml
+++ b/config/default/core.entity_form_display.media.video.media_browser.yml
@@ -23,6 +23,12 @@ content:
       display_label: true
     third_party_settings: {  }
     region: content
+  langcode:
+    type: language_select
+    weight: 2
+    region: content
+    settings: {  }
+    third_party_settings: {  }
   name:
     type: string_textfield
     weight: 0

--- a/config/default/core.entity_form_display.node.knowledge_base.default.yml
+++ b/config/default/core.entity_form_display.node.knowledge_base.default.yml
@@ -65,6 +65,12 @@ content:
     third_party_settings: {  }
     type: link_default
     region: content
+  langcode:
+    type: language_select
+    weight: 2
+    region: content
+    settings: {  }
+    third_party_settings: {  }
   path:
     type: path
     weight: 30

--- a/config/default/core.entity_form_display.node.landing_page.default.yml
+++ b/config/default/core.entity_form_display.node.landing_page.default.yml
@@ -50,6 +50,12 @@ content:
     third_party_settings: {  }
     type: text_textarea
     region: content
+  langcode:
+    type: language_select
+    weight: 2
+    region: content
+    settings: {  }
+    third_party_settings: {  }
   panelizer:
     type: panelizer
     weight: 6

--- a/config/default/core.entity_form_display.node.news_article.default.yml
+++ b/config/default/core.entity_form_display.node.news_article.default.yml
@@ -47,6 +47,12 @@ content:
     third_party_settings: {  }
     type: entity_reference_autocomplete
     region: content
+  langcode:
+    type: language_select
+    weight: 2
+    region: content
+    settings: {  }
+    third_party_settings: {  }
   path:
     type: path
     weight: 30

--- a/config/default/core.entity_form_display.node.page.default.yml
+++ b/config/default/core.entity_form_display.node.page.default.yml
@@ -51,6 +51,12 @@ content:
     third_party_settings: {  }
     type: text_textarea
     region: content
+  langcode:
+    type: language_select
+    weight: 2
+    region: content
+    settings: {  }
+    third_party_settings: {  }
   path:
     type: path
     weight: 5

--- a/config/default/core.entity_form_display.node.pricing_plan.default.yml
+++ b/config/default/core.entity_form_display.node.pricing_plan.default.yml
@@ -63,6 +63,12 @@ content:
     third_party_settings: {  }
     type: string_textfield
     region: content
+  langcode:
+    type: language_select
+    weight: 2
+    region: content
+    settings: {  }
+    third_party_settings: {  }
   path:
     type: path
     weight: 30

--- a/config/default/core.entity_form_display.node.site.default.yml
+++ b/config/default/core.entity_form_display.node.site.default.yml
@@ -3,16 +3,16 @@ langcode: en
 status: true
 dependencies:
   config:
+    - entity_browser.browser.image_browser
     - field.field.node.site.body
     - field.field.node.site.field_agency
     - field.field.node.site.field_environment
     - field.field.node.site.field_link
     - field.field.node.site.field_screenshot
     - field.field.node.site.field_status
-    - image.style.thumbnail
     - node.type.site
   module:
-    - image
+    - entity_browser
     - link
     - path
     - text
@@ -75,6 +75,7 @@ content:
       open: true
       selection_mode: selection_append
     third_party_settings: {  }
+    region: content
   field_status:
     weight: 37
     settings:
@@ -84,6 +85,12 @@ content:
     third_party_settings: {  }
     type: entity_reference_autocomplete
     region: content
+  langcode:
+    type: language_select
+    weight: 2
+    region: content
+    settings: {  }
+    third_party_settings: {  }
   path:
     type: path
     weight: 30

--- a/config/default/core.entity_form_display.node.testimonial.default.yml
+++ b/config/default/core.entity_form_display.node.testimonial.default.yml
@@ -48,6 +48,12 @@ content:
     third_party_settings: {  }
     type: string_textfield
     region: content
+  langcode:
+    type: language_select
+    weight: 2
+    region: content
+    settings: {  }
+    third_party_settings: {  }
   path:
     type: path
     weight: 30

--- a/config/default/core.entity_form_display.scheduled_update.multiple_node_embargo.default.yml
+++ b/config/default/core.entity_form_display.scheduled_update.multiple_node_embargo.default.yml
@@ -18,7 +18,7 @@ content:
     region: content
     settings:
       match_operator: CONTAINS
-      size: '60'
+      size: 60
       placeholder: ''
     third_party_settings: {  }
   field_moderation_state:

--- a/config/default/core.entity_form_display.taxonomy_term.agency.default.yml
+++ b/config/default/core.entity_form_display.taxonomy_term.agency.default.yml
@@ -31,6 +31,12 @@ content:
     third_party_settings: {  }
     type: image_image
     region: content
+  langcode:
+    type: language_select
+    weight: 2
+    region: content
+    settings: {  }
+    third_party_settings: {  }
   name:
     type: string_textfield
     weight: -5

--- a/config/default/core.entity_form_display.user.user.default.yml
+++ b/config/default/core.entity_form_display.user.user.default.yml
@@ -45,4 +45,5 @@ content:
   timezone:
     weight: 6
     region: content
-hidden: {  }
+hidden:
+  langcode: true

--- a/config/default/core.entity_view_display.block_content.basic.default.yml
+++ b/config/default/core.entity_view_display.block_content.basic.default.yml
@@ -21,4 +21,5 @@ content:
     settings: {  }
     third_party_settings: {  }
     region: content
-hidden: {  }
+hidden:
+  langcode: true

--- a/config/default/core.entity_view_display.block_content.block_with_background.default.yml
+++ b/config/default/core.entity_view_display.block_content.block_with_background.default.yml
@@ -24,3 +24,4 @@ content:
 hidden:
   field_background: true
   field_background_orientation: true
+  langcode: true

--- a/config/default/core.entity_view_display.contact_message.apply_for_a_siteno.default.yml
+++ b/config/default/core.entity_view_display.contact_message.apply_for_a_siteno.default.yml
@@ -80,6 +80,7 @@ content:
     type: basic_string
     region: content
 hidden:
+  langcode: true
   mail: true
   message: true
   name: true

--- a/config/default/core.entity_view_display.media.document.default.yml
+++ b/config/default/core.entity_view_display.media.document.default.yml
@@ -61,3 +61,4 @@ content:
     region: content
 hidden:
   field_media_in_library: true
+  langcode: true

--- a/config/default/core.entity_view_display.media.document.embedded.yml
+++ b/config/default/core.entity_view_display.media.document.embedded.yml
@@ -26,6 +26,7 @@ content:
 hidden:
   created: true
   field_media_in_library: true
+  langcode: true
   name: true
   thumbnail: true
   uid: true

--- a/config/default/core.entity_view_display.media.document.thumbnail.yml
+++ b/config/default/core.entity_view_display.media.document.thumbnail.yml
@@ -30,5 +30,6 @@ hidden:
   created: true
   field_document: true
   field_media_in_library: true
+  langcode: true
   name: true
   uid: true

--- a/config/default/core.entity_view_display.media.image.default.yml
+++ b/config/default/core.entity_view_display.media.image.default.yml
@@ -27,6 +27,7 @@ content:
 hidden:
   created: true
   field_media_in_library: true
+  langcode: true
   name: true
   thumbnail: true
   uid: true

--- a/config/default/core.entity_view_display.media.image.embedded.yml
+++ b/config/default/core.entity_view_display.media.image.embedded.yml
@@ -28,6 +28,7 @@ content:
 hidden:
   created: true
   field_media_in_library: true
+  langcode: true
   name: true
   thumbnail: true
   uid: true

--- a/config/default/core.entity_view_display.media.image.thumbnail.yml
+++ b/config/default/core.entity_view_display.media.image.thumbnail.yml
@@ -29,6 +29,7 @@ content:
 hidden:
   created: true
   field_media_in_library: true
+  langcode: true
   name: true
   thumbnail: true
   uid: true

--- a/config/default/core.entity_view_display.media.instagram.default.yml
+++ b/config/default/core.entity_view_display.media.instagram.default.yml
@@ -20,13 +20,14 @@ content:
     weight: 0
     label: visually_hidden
     settings:
-      width: '480'
+      width: 480
       height: '640'
     third_party_settings: {  }
     region: content
 hidden:
   created: true
   field_media_in_library: true
+  langcode: true
   name: true
   thumbnail: true
   uid: true

--- a/config/default/core.entity_view_display.media.instagram.embedded.yml
+++ b/config/default/core.entity_view_display.media.instagram.embedded.yml
@@ -21,13 +21,14 @@ content:
     weight: 0
     label: hidden
     settings:
-      width: '480'
+      width: 480
       height: '640'
     third_party_settings: {  }
     region: content
 hidden:
   created: true
   field_media_in_library: true
+  langcode: true
   name: true
   thumbnail: true
   uid: true

--- a/config/default/core.entity_view_display.media.instagram.thumbnail.yml
+++ b/config/default/core.entity_view_display.media.instagram.thumbnail.yml
@@ -30,5 +30,6 @@ hidden:
   created: true
   embed_code: true
   field_media_in_library: true
+  langcode: true
   name: true
   uid: true

--- a/config/default/core.entity_view_display.media.tweet.default.yml
+++ b/config/default/core.entity_view_display.media.tweet.default.yml
@@ -25,6 +25,7 @@ content:
 hidden:
   created: true
   field_media_in_library: true
+  langcode: true
   name: true
   thumbnail: true
   uid: true

--- a/config/default/core.entity_view_display.media.tweet.embedded.yml
+++ b/config/default/core.entity_view_display.media.tweet.embedded.yml
@@ -26,6 +26,7 @@ content:
 hidden:
   created: true
   field_media_in_library: true
+  langcode: true
   name: true
   thumbnail: true
   uid: true

--- a/config/default/core.entity_view_display.media.tweet.thumbnail.yml
+++ b/config/default/core.entity_view_display.media.tweet.thumbnail.yml
@@ -30,5 +30,6 @@ hidden:
   created: true
   embed_code: true
   field_media_in_library: true
+  langcode: true
   name: true
   uid: true

--- a/config/default/core.entity_view_display.media.video.default.yml
+++ b/config/default/core.entity_view_display.media.video.default.yml
@@ -32,8 +32,8 @@ content:
     label: hidden
     settings:
       responsive: true
-      width: '854'
-      height: '480'
+      width: 854
+      height: 480
       autoplay: true
     third_party_settings: {  }
     region: content
@@ -54,4 +54,5 @@ content:
     region: content
 hidden:
   field_media_in_library: true
+  langcode: true
   thumbnail: true

--- a/config/default/core.entity_view_display.media.video.embedded.yml
+++ b/config/default/core.entity_view_display.media.video.embedded.yml
@@ -22,14 +22,15 @@ content:
     label: hidden
     settings:
       responsive: true
-      width: '854'
-      height: '480'
+      width: 854
+      height: 480
       autoplay: true
     third_party_settings: {  }
     region: content
 hidden:
   created: true
   field_media_in_library: true
+  langcode: true
   name: true
   thumbnail: true
   uid: true

--- a/config/default/core.entity_view_display.media.video.thumbnail.yml
+++ b/config/default/core.entity_view_display.media.video.thumbnail.yml
@@ -30,5 +30,6 @@ hidden:
   created: true
   field_media_in_library: true
   field_media_video_embed_field: true
+  langcode: true
   name: true
   uid: true

--- a/config/default/core.entity_view_display.node.knowledge_base.default.yml
+++ b/config/default/core.entity_view_display.node.knowledge_base.default.yml
@@ -64,4 +64,5 @@ content:
   links:
     weight: 100
     region: content
-hidden: {  }
+hidden:
+  langcode: true

--- a/config/default/core.entity_view_display.node.knowledge_base.teaser.yml
+++ b/config/default/core.entity_view_display.node.knowledge_base.teaser.yml
@@ -5,6 +5,10 @@ dependencies:
   config:
     - core.entity_view_mode.node.teaser
     - field.field.node.knowledge_base.body
+    - field.field.node.knowledge_base.field_document_file_upload
+    - field.field.node.knowledge_base.field_document_reference
+    - field.field.node.knowledge_base.field_document_status
+    - field.field.node.knowledge_base.field_document_url
     - node.type.knowledge_base
   module:
     - text
@@ -25,4 +29,9 @@ content:
   links:
     weight: 100
     region: content
-hidden: {  }
+hidden:
+  field_document_file_upload: true
+  field_document_reference: true
+  field_document_status: true
+  field_document_url: true
+  langcode: true

--- a/config/default/core.entity_view_display.node.landing_page.default.yml
+++ b/config/default/core.entity_view_display.node.landing_page.default.yml
@@ -164,5 +164,6 @@ content:
     third_party_settings: {  }
 hidden:
   field_meta_tags: true
+  langcode: true
   links: true
   panelizer: true

--- a/config/default/core.entity_view_display.node.landing_page.full.yml
+++ b/config/default/core.entity_view_display.node.landing_page.full.yml
@@ -6,6 +6,7 @@ dependencies:
     - core.entity_view_mode.node.full
     - field.field.node.landing_page.body
     - field.field.node.landing_page.field_meta_tags
+    - field.field.node.landing_page.field_summary
     - field.field.node.landing_page.panelizer
     - node.type.landing_page
   module:
@@ -103,4 +104,6 @@ content:
     region: content
 hidden:
   body: true
+  field_summary: true
+  langcode: true
   panelizer: true

--- a/config/default/core.entity_view_display.node.landing_page.site_logo.yml
+++ b/config/default/core.entity_view_display.node.landing_page.site_logo.yml
@@ -6,6 +6,7 @@ dependencies:
     - core.entity_view_mode.node.site_logo
     - field.field.node.landing_page.body
     - field.field.node.landing_page.field_meta_tags
+    - field.field.node.landing_page.field_summary
     - field.field.node.landing_page.panelizer
     - node.type.landing_page
   module:
@@ -170,4 +171,6 @@ content:
     settings: {  }
     third_party_settings: {  }
 hidden:
+  field_summary: true
+  langcode: true
   panelizer: true

--- a/config/default/core.entity_view_display.node.landing_page.teaser.yml
+++ b/config/default/core.entity_view_display.node.landing_page.teaser.yml
@@ -6,6 +6,7 @@ dependencies:
     - core.entity_view_mode.node.teaser
     - field.field.node.landing_page.body
     - field.field.node.landing_page.field_meta_tags
+    - field.field.node.landing_page.field_summary
     - field.field.node.landing_page.panelizer
     - node.type.landing_page
   module:
@@ -45,4 +46,6 @@ content:
     third_party_settings: {  }
     region: content
 hidden:
+  field_summary: true
+  langcode: true
   panelizer: true

--- a/config/default/core.entity_view_display.node.news_article.default.yml
+++ b/config/default/core.entity_view_display.node.news_article.default.yml
@@ -43,4 +43,5 @@ content:
   links:
     weight: 100
     region: content
-hidden: {  }
+hidden:
+  langcode: true

--- a/config/default/core.entity_view_display.node.news_article.teaser.yml
+++ b/config/default/core.entity_view_display.node.news_article.teaser.yml
@@ -5,6 +5,8 @@ dependencies:
   config:
     - core.entity_view_mode.node.teaser
     - field.field.node.news_article.body
+    - field.field.node.news_article.field_date
+    - field.field.node.news_article.field_tags
     - node.type.news_article
   module:
     - text
@@ -25,4 +27,7 @@ content:
   links:
     weight: 100
     region: content
-hidden: {  }
+hidden:
+  field_date: true
+  field_tags: true
+  langcode: true

--- a/config/default/core.entity_view_display.node.page.default.yml
+++ b/config/default/core.entity_view_display.node.page.default.yml
@@ -50,5 +50,6 @@ content:
     weight: -20
     region: content
 hidden:
+  langcode: true
   panelizer: true
   scheduled_update: true

--- a/config/default/core.entity_view_display.node.page.teaser.yml
+++ b/config/default/core.entity_view_display.node.page.teaser.yml
@@ -6,9 +6,12 @@ dependencies:
     - core.entity_view_mode.node.teaser
     - field.field.node.page.body
     - field.field.node.page.field_meta_tags
+    - field.field.node.page.field_summary
+    - field.field.node.page.panelizer
     - field.field.node.page.scheduled_update
     - node.type.page
   module:
+    - panelizer
     - text
     - user
 third_party_settings:
@@ -41,5 +44,6 @@ content:
 hidden:
   field_meta_tags: true
   field_summary: true
+  langcode: true
   panelizer: true
   scheduled_update: true

--- a/config/default/core.entity_view_display.node.pricing_plan.default.yml
+++ b/config/default/core.entity_view_display.node.pricing_plan.default.yml
@@ -59,4 +59,5 @@ content:
   links:
     weight: 100
     region: content
-hidden: {  }
+hidden:
+  langcode: true

--- a/config/default/core.entity_view_display.node.pricing_plan.teaser.yml
+++ b/config/default/core.entity_view_display.node.pricing_plan.teaser.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - core.entity_view_mode.node.teaser
+    - field.field.node.pricing_plan.field_additional_site_cap
     - field.field.node.pricing_plan.field_additional_sites_per_year
     - field.field.node.pricing_plan.field_cost_per_year
     - field.field.node.pricing_plan.field_page_views_per_month
@@ -20,7 +21,9 @@ content:
     weight: 100
     region: content
 hidden:
+  field_additional_site_cap: true
   field_additional_sites_per_year: true
   field_cost_per_year: true
   field_page_views_per_month: true
   field_setup_fee: true
+  langcode: true

--- a/config/default/core.entity_view_display.node.site.card.yml
+++ b/config/default/core.entity_view_display.node.site.card.yml
@@ -58,3 +58,4 @@ hidden:
   field_agency: true
   field_environment: true
   field_status: true
+  langcode: true

--- a/config/default/core.entity_view_display.node.site.default.yml
+++ b/config/default/core.entity_view_display.node.site.default.yml
@@ -84,4 +84,5 @@ content:
     region: content
     settings: {  }
     third_party_settings: {  }
-hidden: {  }
+hidden:
+  langcode: true

--- a/config/default/core.entity_view_display.node.site.site_logo.yml
+++ b/config/default/core.entity_view_display.node.site.site_logo.yml
@@ -8,6 +8,7 @@ dependencies:
     - field.field.node.site.field_agency
     - field.field.node.site.field_environment
     - field.field.node.site.field_link
+    - field.field.node.site.field_screenshot
     - field.field.node.site.field_status
     - node.type.site
   module:
@@ -34,4 +35,6 @@ hidden:
   field_agency: true
   field_environment: true
   field_link: true
+  field_screenshot: true
   field_status: true
+  langcode: true

--- a/config/default/core.entity_view_display.node.site.teaser.yml
+++ b/config/default/core.entity_view_display.node.site.teaser.yml
@@ -5,6 +5,11 @@ dependencies:
   config:
     - core.entity_view_mode.node.teaser
     - field.field.node.site.body
+    - field.field.node.site.field_agency
+    - field.field.node.site.field_environment
+    - field.field.node.site.field_link
+    - field.field.node.site.field_screenshot
+    - field.field.node.site.field_status
     - node.type.site
   module:
     - text
@@ -25,4 +30,10 @@ content:
   links:
     weight: 100
     region: content
-hidden: {  }
+hidden:
+  field_agency: true
+  field_environment: true
+  field_link: true
+  field_screenshot: true
+  field_status: true
+  langcode: true

--- a/config/default/core.entity_view_display.node.testimonial.default.yml
+++ b/config/default/core.entity_view_display.node.testimonial.default.yml
@@ -47,4 +47,5 @@ content:
     type: string
     region: content
 hidden:
+  langcode: true
   links: true

--- a/config/default/core.entity_view_display.node.testimonial.teaser.yml
+++ b/config/default/core.entity_view_display.node.testimonial.teaser.yml
@@ -5,6 +5,8 @@ dependencies:
   config:
     - core.entity_view_mode.node.teaser
     - field.field.node.testimonial.body
+    - field.field.node.testimonial.field_agency
+    - field.field.node.testimonial.field_position
     - node.type.testimonial
   module:
     - text
@@ -25,4 +27,7 @@ content:
   links:
     weight: 100
     region: content
-hidden: {  }
+hidden:
+  field_agency: true
+  field_position: true
+  langcode: true

--- a/config/default/core.entity_view_display.taxonomy_term.agency.default.yml
+++ b/config/default/core.entity_view_display.taxonomy_term.agency.default.yml
@@ -30,3 +30,4 @@ content:
     region: content
 hidden:
   description: true
+  langcode: true

--- a/config/default/core.entity_view_display.taxonomy_term.agency.list.yml
+++ b/config/default/core.entity_view_display.taxonomy_term.agency.list.yml
@@ -30,4 +30,5 @@ content:
     third_party_settings: {  }
     type: image
     region: content
-hidden: {  }
+hidden:
+  langcode: true

--- a/config/default/core.extension.yml
+++ b/config/default/core.extension.yml
@@ -6,6 +6,7 @@ module:
   ckeditor: 0
   comment: 0
   config: 0
+  config_translation: 0
   config_update: 0
   contact: 0
   contact_storage: 0
@@ -29,6 +30,7 @@ module:
   field_ui: 0
   file: 0
   filter: 0
+  govcms_dlm: 0
   govcms_linkit: 0
   govcms_password_policy: 0
   govcms_user_actions: 0
@@ -37,6 +39,7 @@ module:
   image: 0
   inline_entity_form: 0
   kint: 0
+  language: 0
   layout_discovery: 0
   lightning_contact_form: 0
   lightning_core: 0
@@ -54,6 +57,7 @@ module:
   lightning_workflow: 0
   link: 0
   linkit: 0
+  locale: 0
   log_entity: 0
   log_entity_login_attempts: 0
   media_entity: 0
@@ -103,6 +107,7 @@ module:
   workflows: 0
   menu_link_content: 1
   pathauto: 1
+  content_translation: 10
   views: 10
   lightning: 1000
 theme:

--- a/config/default/field.field.block_content.basic.body.yml
+++ b/config/default/field.field.block_content.basic.body.yml
@@ -16,7 +16,7 @@ bundle: basic
 label: Body
 description: ''
 required: false
-translatable: true
+translatable: false
 default_value: {  }
 default_value_callback: ''
 settings:

--- a/config/default/field.field.block_content.basic.body.yml
+++ b/config/default/field.field.block_content.basic.body.yml
@@ -16,7 +16,7 @@ bundle: basic
 label: Body
 description: ''
 required: false
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings:

--- a/config/default/field.field.block_content.block_with_background.body.yml
+++ b/config/default/field.field.block_content.block_with_background.body.yml
@@ -14,7 +14,7 @@ bundle: block_with_background
 label: Body
 description: ''
 required: false
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings:

--- a/config/default/field.field.block_content.block_with_background.body.yml
+++ b/config/default/field.field.block_content.block_with_background.body.yml
@@ -14,7 +14,7 @@ bundle: block_with_background
 label: Body
 description: ''
 required: false
-translatable: true
+translatable: false
 default_value: {  }
 default_value_callback: ''
 settings:

--- a/config/default/field.field.block_content.block_with_background.field_background.yml
+++ b/config/default/field.field.block_content.block_with_background.field_background.yml
@@ -14,7 +14,7 @@ bundle: block_with_background
 label: Background
 description: 'Choose which background colour to apply to the block.'
 required: true
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings: {  }

--- a/config/default/field.field.block_content.block_with_background.field_background_orientation.yml
+++ b/config/default/field.field.block_content.block_with_background.field_background_orientation.yml
@@ -14,7 +14,7 @@ bundle: block_with_background
 label: 'Background orientation'
 description: ''
 required: true
-translatable: false
+translatable: true
 default_value:
   -
     value: vertical

--- a/config/default/field.field.media.document.field_media_in_library.yml
+++ b/config/default/field.field.media.document.field_media_in_library.yml
@@ -14,7 +14,7 @@ bundle: document
 label: 'Save to my media library'
 description: ''
 required: false
-translatable: true
+translatable: false
 default_value:
   -
     value: 1

--- a/config/default/field.field.media.video.field_media_in_library.yml
+++ b/config/default/field.field.media.video.field_media_in_library.yml
@@ -14,7 +14,7 @@ bundle: video
 label: 'Save to my media library'
 description: ''
 required: false
-translatable: true
+translatable: false
 default_value:
   -
     value: 1

--- a/config/default/field.field.media.video.field_media_video_embed_field.yml
+++ b/config/default/field.field.media.video.field_media_video_embed_field.yml
@@ -16,7 +16,7 @@ bundle: video
 label: 'Video URL'
 description: ''
 required: true
-translatable: true
+translatable: false
 default_value: {  }
 default_value_callback: ''
 settings:

--- a/config/default/field.field.node.knowledge_base.body.yml
+++ b/config/default/field.field.node.knowledge_base.body.yml
@@ -14,7 +14,7 @@ bundle: knowledge_base
 label: Body
 description: ''
 required: false
-translatable: true
+translatable: false
 default_value: {  }
 default_value_callback: ''
 settings:

--- a/config/default/field.field.node.landing_page.body.yml
+++ b/config/default/field.field.node.landing_page.body.yml
@@ -16,7 +16,7 @@ bundle: landing_page
 label: Description
 description: 'A description of this page, for use in teasers and lists of content.'
 required: false
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings:

--- a/config/default/field.field.node.landing_page.body.yml
+++ b/config/default/field.field.node.landing_page.body.yml
@@ -16,7 +16,7 @@ bundle: landing_page
 label: Description
 description: 'A description of this page, for use in teasers and lists of content.'
 required: false
-translatable: true
+translatable: false
 default_value: {  }
 default_value_callback: ''
 settings:

--- a/config/default/field.field.node.landing_page.field_meta_tags.yml
+++ b/config/default/field.field.node.landing_page.field_meta_tags.yml
@@ -16,7 +16,7 @@ bundle: landing_page
 label: 'Meta tags'
 description: ''
 required: false
-translatable: false
+translatable: true
 default_value:
   -
     value: 'a:1:{s:5:"title";s:34:"[current-page:title] | [site:name]";}'

--- a/config/default/field.field.node.landing_page.field_meta_tags.yml
+++ b/config/default/field.field.node.landing_page.field_meta_tags.yml
@@ -16,7 +16,7 @@ bundle: landing_page
 label: 'Meta tags'
 description: ''
 required: false
-translatable: true
+translatable: false
 default_value:
   -
     value: 'a:1:{s:5:"title";s:34:"[current-page:title] | [site:name]";}'

--- a/config/default/field.field.node.landing_page.field_summary.yml
+++ b/config/default/field.field.node.landing_page.field_summary.yml
@@ -14,7 +14,7 @@ bundle: landing_page
 label: 'Lead in'
 description: ''
 required: false
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings: {  }

--- a/config/default/field.field.node.landing_page.panelizer.yml
+++ b/config/default/field.field.node.landing_page.panelizer.yml
@@ -16,7 +16,7 @@ bundle: landing_page
 label: Panelizer
 description: ''
 required: false
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings: {  }

--- a/config/default/field.field.node.landing_page.panelizer.yml
+++ b/config/default/field.field.node.landing_page.panelizer.yml
@@ -16,7 +16,7 @@ bundle: landing_page
 label: Panelizer
 description: ''
 required: false
-translatable: true
+translatable: false
 default_value: {  }
 default_value_callback: ''
 settings: {  }

--- a/config/default/field.field.node.news_article.field_date.yml
+++ b/config/default/field.field.node.news_article.field_date.yml
@@ -14,7 +14,7 @@ bundle: news_article
 label: Date
 description: 'Date that this news content took place.'
 required: false
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings: {  }

--- a/config/default/field.field.node.news_article.field_tags.yml
+++ b/config/default/field.field.node.news_article.field_tags.yml
@@ -13,7 +13,7 @@ bundle: news_article
 label: Tags
 description: 'Enter a comma-separated list of words to describe your content.'
 required: false
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings:

--- a/config/default/field.field.node.page.field_meta_tags.yml
+++ b/config/default/field.field.node.page.field_meta_tags.yml
@@ -16,7 +16,7 @@ bundle: page
 label: 'Meta tags'
 description: ''
 required: false
-translatable: false
+translatable: true
 default_value:
   -
     value: 'a:1:{s:5:"title";s:34:"[current-page:title] | [site:name]";}'

--- a/config/default/field.field.node.site.body.yml
+++ b/config/default/field.field.node.site.body.yml
@@ -14,7 +14,7 @@ bundle: site
 label: Body
 description: ''
 required: false
-translatable: true
+translatable: false
 default_value: {  }
 default_value_callback: ''
 settings:

--- a/config/default/field.field.node.testimonial.body.yml
+++ b/config/default/field.field.node.testimonial.body.yml
@@ -14,7 +14,7 @@ bundle: testimonial
 label: Content
 description: ''
 required: true
-translatable: true
+translatable: false
 default_value: {  }
 default_value_callback: ''
 settings:

--- a/config/default/field.field.node.testimonial.field_agency.yml
+++ b/config/default/field.field.node.testimonial.field_agency.yml
@@ -13,7 +13,7 @@ bundle: testimonial
 label: Agency
 description: ''
 required: true
-translatable: true
+translatable: false
 default_value: {  }
 default_value_callback: ''
 settings:

--- a/config/default/field.field.taxonomy_term.agency.field_logo.yml
+++ b/config/default/field.field.taxonomy_term.agency.field_logo.yml
@@ -6,7 +6,14 @@ dependencies:
     - field.storage.taxonomy_term.field_logo
     - taxonomy.vocabulary.agency
   module:
+    - content_translation
     - image
+third_party_settings:
+  content_translation:
+    translation_sync:
+      alt: alt
+      title: title
+      file: '0'
 id: taxonomy_term.agency.field_logo
 field_name: field_logo
 entity_type: taxonomy_term
@@ -14,7 +21,7 @@ bundle: agency
 label: Logo
 description: ''
 required: false
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings:

--- a/config/default/govcms_dlm.settings.yml
+++ b/config/default/govcms_dlm.settings.yml
@@ -1,0 +1,3 @@
+suffix: '[SEC=UNCLASSIFIED]'
+_core:
+  default_config_hash: TvCv3QmUZdbPWAaMsyJRbG77Vp3-PH9zxHmTJbhRnCI

--- a/config/default/language.content_settings.block_content.basic.yml
+++ b/config/default/language.content_settings.block_content.basic.yml
@@ -8,9 +8,9 @@ dependencies:
     - content_translation
 third_party_settings:
   content_translation:
-    enabled: false
+    enabled: true
 id: block_content.basic
 target_entity_type_id: block_content
 target_bundle: basic
 default_langcode: site_default
-language_alterable: false
+language_alterable: true

--- a/config/default/language.content_settings.block_content.basic.yml
+++ b/config/default/language.content_settings.block_content.basic.yml
@@ -1,0 +1,16 @@
+uuid: c2f5e4ac-5403-4b53-a481-dc0a795338db
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.basic
+  module:
+    - content_translation
+third_party_settings:
+  content_translation:
+    enabled: false
+id: block_content.basic
+target_entity_type_id: block_content
+target_bundle: basic
+default_langcode: site_default
+language_alterable: false

--- a/config/default/language.content_settings.block_content.block_with_background.yml
+++ b/config/default/language.content_settings.block_content.block_with_background.yml
@@ -8,9 +8,9 @@ dependencies:
     - content_translation
 third_party_settings:
   content_translation:
-    enabled: false
+    enabled: true
 id: block_content.block_with_background
 target_entity_type_id: block_content
 target_bundle: block_with_background
 default_langcode: site_default
-language_alterable: false
+language_alterable: true

--- a/config/default/language.content_settings.block_content.block_with_background.yml
+++ b/config/default/language.content_settings.block_content.block_with_background.yml
@@ -1,0 +1,16 @@
+uuid: b812c2c2-7df6-482e-bc32-10ec324b7b27
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.block_with_background
+  module:
+    - content_translation
+third_party_settings:
+  content_translation:
+    enabled: false
+id: block_content.block_with_background
+target_entity_type_id: block_content
+target_bundle: block_with_background
+default_langcode: site_default
+language_alterable: false

--- a/config/default/language.content_settings.contact_message.apply_for_a_siteno.yml
+++ b/config/default/language.content_settings.contact_message.apply_for_a_siteno.yml
@@ -1,0 +1,11 @@
+uuid: 38bc1ec0-9865-4117-9533-b0d301e17806
+langcode: en
+status: true
+dependencies:
+  config:
+    - contact.form.apply_for_a_siteno
+id: contact_message.apply_for_a_siteno
+target_entity_type_id: contact_message
+target_bundle: apply_for_a_siteno
+default_langcode: site_default
+language_alterable: false

--- a/config/default/language.content_settings.contact_message.personal.yml
+++ b/config/default/language.content_settings.contact_message.personal.yml
@@ -1,0 +1,11 @@
+uuid: 80c92d39-0e35-4156-baae-20a25141978f
+langcode: en
+status: true
+dependencies:
+  config:
+    - contact.form.personal
+id: contact_message.personal
+target_entity_type_id: contact_message
+target_bundle: personal
+default_langcode: site_default
+language_alterable: false

--- a/config/default/language.content_settings.contact_message.sitewide.yml
+++ b/config/default/language.content_settings.contact_message.sitewide.yml
@@ -1,0 +1,11 @@
+uuid: 9d87b82a-d611-4b4b-93e2-a56bdbfab21a
+langcode: en
+status: true
+dependencies:
+  config:
+    - contact.form.sitewide
+id: contact_message.sitewide
+target_entity_type_id: contact_message
+target_bundle: sitewide
+default_langcode: site_default
+language_alterable: false

--- a/config/default/language.content_settings.file.file.yml
+++ b/config/default/language.content_settings.file.file.yml
@@ -1,0 +1,11 @@
+uuid: 63d2c845-f5ab-41d0-a5ba-87a7852aa1b7
+langcode: en
+status: true
+dependencies:
+  module:
+    - file
+id: file.file
+target_entity_type_id: file
+target_bundle: file
+default_langcode: site_default
+language_alterable: false

--- a/config/default/language.content_settings.log_entity.log_entity.yml
+++ b/config/default/language.content_settings.log_entity.log_entity.yml
@@ -1,0 +1,11 @@
+uuid: cb177d90-316b-4c40-8dce-38028d35fbbb
+langcode: en
+status: true
+dependencies:
+  module:
+    - log_entity
+id: log_entity.log_entity
+target_entity_type_id: log_entity
+target_bundle: log_entity
+default_langcode: site_default
+language_alterable: false

--- a/config/default/language.content_settings.media.document.yml
+++ b/config/default/language.content_settings.media.document.yml
@@ -1,0 +1,16 @@
+uuid: 0c4ca52f-f4aa-49d2-8f65-432ddbefabad
+langcode: en
+status: true
+dependencies:
+  config:
+    - media_entity.bundle.document
+  module:
+    - content_translation
+third_party_settings:
+  content_translation:
+    enabled: false
+id: media.document
+target_entity_type_id: media
+target_bundle: document
+default_langcode: site_default
+language_alterable: false

--- a/config/default/language.content_settings.media.image.yml
+++ b/config/default/language.content_settings.media.image.yml
@@ -1,0 +1,16 @@
+uuid: 9bf1f323-969b-401f-a54d-a53fb394b490
+langcode: en
+status: true
+dependencies:
+  config:
+    - media_entity.bundle.image
+  module:
+    - content_translation
+third_party_settings:
+  content_translation:
+    enabled: false
+id: media.image
+target_entity_type_id: media
+target_bundle: image
+default_langcode: site_default
+language_alterable: false

--- a/config/default/language.content_settings.media.instagram.yml
+++ b/config/default/language.content_settings.media.instagram.yml
@@ -1,0 +1,16 @@
+uuid: dcaae9df-2bc8-4f73-a7aa-022a037a0fa6
+langcode: en
+status: true
+dependencies:
+  config:
+    - media_entity.bundle.instagram
+  module:
+    - content_translation
+third_party_settings:
+  content_translation:
+    enabled: false
+id: media.instagram
+target_entity_type_id: media
+target_bundle: instagram
+default_langcode: site_default
+language_alterable: false

--- a/config/default/language.content_settings.media.tweet.yml
+++ b/config/default/language.content_settings.media.tweet.yml
@@ -1,0 +1,16 @@
+uuid: 574356e0-19de-4e3f-ad35-f580bc204016
+langcode: en
+status: true
+dependencies:
+  config:
+    - media_entity.bundle.tweet
+  module:
+    - content_translation
+third_party_settings:
+  content_translation:
+    enabled: false
+id: media.tweet
+target_entity_type_id: media
+target_bundle: tweet
+default_langcode: site_default
+language_alterable: false

--- a/config/default/language.content_settings.media.video.yml
+++ b/config/default/language.content_settings.media.video.yml
@@ -1,0 +1,16 @@
+uuid: 5bef8cdf-5686-4cc3-9519-2ec6acdbbe10
+langcode: en
+status: true
+dependencies:
+  config:
+    - media_entity.bundle.video
+  module:
+    - content_translation
+third_party_settings:
+  content_translation:
+    enabled: false
+id: media.video
+target_entity_type_id: media
+target_bundle: video
+default_langcode: site_default
+language_alterable: false

--- a/config/default/language.content_settings.menu_link_content.menu_link_content.yml
+++ b/config/default/language.content_settings.menu_link_content.menu_link_content.yml
@@ -1,0 +1,15 @@
+uuid: c112a590-3b98-44ce-808f-0b87633af47e
+langcode: en
+status: true
+dependencies:
+  module:
+    - content_translation
+    - menu_link_content
+third_party_settings:
+  content_translation:
+    enabled: false
+id: menu_link_content.menu_link_content
+target_entity_type_id: menu_link_content
+target_bundle: menu_link_content
+default_langcode: site_default
+language_alterable: false

--- a/config/default/language.content_settings.node.knowledge_base.yml
+++ b/config/default/language.content_settings.node.knowledge_base.yml
@@ -1,0 +1,16 @@
+uuid: 351c3e52-1c70-4650-94d2-c5dc2de7b0f6
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.knowledge_base
+  module:
+    - content_translation
+third_party_settings:
+  content_translation:
+    enabled: false
+id: node.knowledge_base
+target_entity_type_id: node
+target_bundle: knowledge_base
+default_langcode: site_default
+language_alterable: false

--- a/config/default/language.content_settings.node.landing_page.yml
+++ b/config/default/language.content_settings.node.landing_page.yml
@@ -1,0 +1,16 @@
+uuid: 8c7037bc-fc91-4c0e-a3ab-761712726165
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.landing_page
+  module:
+    - content_translation
+third_party_settings:
+  content_translation:
+    enabled: false
+id: node.landing_page
+target_entity_type_id: node
+target_bundle: landing_page
+default_langcode: site_default
+language_alterable: false

--- a/config/default/language.content_settings.node.landing_page.yml
+++ b/config/default/language.content_settings.node.landing_page.yml
@@ -8,9 +8,9 @@ dependencies:
     - content_translation
 third_party_settings:
   content_translation:
-    enabled: false
+    enabled: true
 id: node.landing_page
 target_entity_type_id: node
 target_bundle: landing_page
 default_langcode: site_default
-language_alterable: false
+language_alterable: true

--- a/config/default/language.content_settings.node.news_article.yml
+++ b/config/default/language.content_settings.node.news_article.yml
@@ -1,0 +1,16 @@
+uuid: 26541160-b603-4848-b534-bd06958b5259
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.news_article
+  module:
+    - content_translation
+third_party_settings:
+  content_translation:
+    enabled: true
+id: node.news_article
+target_entity_type_id: node
+target_bundle: news_article
+default_langcode: site_default
+language_alterable: true

--- a/config/default/language.content_settings.node.page.yml
+++ b/config/default/language.content_settings.node.page.yml
@@ -1,0 +1,16 @@
+uuid: 2f235c81-3a2b-44c4-a94d-6d214152ce2a
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.page
+  module:
+    - content_translation
+third_party_settings:
+  content_translation:
+    enabled: true
+id: node.page
+target_entity_type_id: node
+target_bundle: page
+default_langcode: site_default
+language_alterable: true

--- a/config/default/language.content_settings.node.pricing_plan.yml
+++ b/config/default/language.content_settings.node.pricing_plan.yml
@@ -1,0 +1,16 @@
+uuid: 5c425673-3256-473b-9fc9-dc6352fdeb35
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.pricing_plan
+  module:
+    - content_translation
+third_party_settings:
+  content_translation:
+    enabled: false
+id: node.pricing_plan
+target_entity_type_id: node
+target_bundle: pricing_plan
+default_langcode: site_default
+language_alterable: false

--- a/config/default/language.content_settings.node.site.yml
+++ b/config/default/language.content_settings.node.site.yml
@@ -1,0 +1,16 @@
+uuid: 79f3c2d3-6fe0-415c-9b2d-d1b91cf5b54b
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.site
+  module:
+    - content_translation
+third_party_settings:
+  content_translation:
+    enabled: false
+id: node.site
+target_entity_type_id: node
+target_bundle: site
+default_langcode: site_default
+language_alterable: false

--- a/config/default/language.content_settings.node.testimonial.yml
+++ b/config/default/language.content_settings.node.testimonial.yml
@@ -1,0 +1,16 @@
+uuid: fea1e904-58cf-4829-92b1-9d32ae791127
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.testimonial
+  module:
+    - content_translation
+third_party_settings:
+  content_translation:
+    enabled: false
+id: node.testimonial
+target_entity_type_id: node
+target_bundle: testimonial
+default_langcode: site_default
+language_alterable: false

--- a/config/default/language.content_settings.shortcut.default.yml
+++ b/config/default/language.content_settings.shortcut.default.yml
@@ -1,0 +1,16 @@
+uuid: 1207620f-0f42-4e2f-b178-681c6eac5844
+langcode: en
+status: true
+dependencies:
+  config:
+    - shortcut.set.default
+  module:
+    - content_translation
+third_party_settings:
+  content_translation:
+    enabled: false
+id: shortcut.default
+target_entity_type_id: shortcut
+target_bundle: default
+default_langcode: site_default
+language_alterable: false

--- a/config/default/language.content_settings.taxonomy_term.agency.yml
+++ b/config/default/language.content_settings.taxonomy_term.agency.yml
@@ -8,9 +8,9 @@ dependencies:
     - content_translation
 third_party_settings:
   content_translation:
-    enabled: false
+    enabled: true
 id: taxonomy_term.agency
 target_entity_type_id: taxonomy_term
 target_bundle: agency
 default_langcode: site_default
-language_alterable: false
+language_alterable: true

--- a/config/default/language.content_settings.taxonomy_term.agency.yml
+++ b/config/default/language.content_settings.taxonomy_term.agency.yml
@@ -1,0 +1,16 @@
+uuid: afbe8491-7d4a-469b-a9b8-5581b2b9329d
+langcode: en
+status: true
+dependencies:
+  config:
+    - taxonomy.vocabulary.agency
+  module:
+    - content_translation
+third_party_settings:
+  content_translation:
+    enabled: false
+id: taxonomy_term.agency
+target_entity_type_id: taxonomy_term
+target_bundle: agency
+default_langcode: site_default
+language_alterable: false

--- a/config/default/language.content_settings.taxonomy_term.environment.yml
+++ b/config/default/language.content_settings.taxonomy_term.environment.yml
@@ -1,0 +1,16 @@
+uuid: 2837a25a-5188-4b78-a69f-565d5e0b72a4
+langcode: en
+status: true
+dependencies:
+  config:
+    - taxonomy.vocabulary.environment
+  module:
+    - content_translation
+third_party_settings:
+  content_translation:
+    enabled: false
+id: taxonomy_term.environment
+target_entity_type_id: taxonomy_term
+target_bundle: environment
+default_langcode: site_default
+language_alterable: false

--- a/config/default/language.content_settings.taxonomy_term.knowledge_base.yml
+++ b/config/default/language.content_settings.taxonomy_term.knowledge_base.yml
@@ -1,0 +1,16 @@
+uuid: 685cb0bc-c2f8-400f-bcfb-ebc05d0ff53c
+langcode: en
+status: true
+dependencies:
+  config:
+    - taxonomy.vocabulary.knowledge_base
+  module:
+    - content_translation
+third_party_settings:
+  content_translation:
+    enabled: false
+id: taxonomy_term.knowledge_base
+target_entity_type_id: taxonomy_term
+target_bundle: knowledge_base
+default_langcode: site_default
+language_alterable: false

--- a/config/default/language.content_settings.taxonomy_term.status.yml
+++ b/config/default/language.content_settings.taxonomy_term.status.yml
@@ -1,0 +1,16 @@
+uuid: 93e8e14b-ece7-42c8-961f-50b1c5140393
+langcode: en
+status: true
+dependencies:
+  config:
+    - taxonomy.vocabulary.status
+  module:
+    - content_translation
+third_party_settings:
+  content_translation:
+    enabled: false
+id: taxonomy_term.status
+target_entity_type_id: taxonomy_term
+target_bundle: status
+default_langcode: site_default
+language_alterable: false

--- a/config/default/language.content_settings.taxonomy_term.tags.yml
+++ b/config/default/language.content_settings.taxonomy_term.tags.yml
@@ -1,0 +1,16 @@
+uuid: 3a75727e-c03b-48e7-b507-14fe7a5554ed
+langcode: en
+status: true
+dependencies:
+  config:
+    - taxonomy.vocabulary.tags
+  module:
+    - content_translation
+third_party_settings:
+  content_translation:
+    enabled: false
+id: taxonomy_term.tags
+target_entity_type_id: taxonomy_term
+target_bundle: tags
+default_langcode: site_default
+language_alterable: false

--- a/config/default/language.content_settings.user.user.yml
+++ b/config/default/language.content_settings.user.user.yml
@@ -1,0 +1,15 @@
+uuid: 1fa78e69-427f-42ec-9f8f-9dfe15135581
+langcode: en
+status: true
+dependencies:
+  module:
+    - content_translation
+    - user
+third_party_settings:
+  content_translation:
+    enabled: false
+id: user.user
+target_entity_type_id: user
+target_bundle: user
+default_langcode: site_default
+language_alterable: false

--- a/config/default/language.entity.ar.yml
+++ b/config/default/language.entity.ar.yml
@@ -1,0 +1,9 @@
+uuid: 5bb5af1d-c4fc-45fc-b0fe-6041137982f4
+langcode: en
+status: true
+dependencies: {  }
+id: ar
+label: Arabic
+direction: rtl
+weight: 2
+locked: false

--- a/config/default/language.entity.en.yml
+++ b/config/default/language.entity.en.yml
@@ -1,0 +1,11 @@
+uuid: 516df210-af72-492d-a979-570b0abe4f04
+langcode: en
+status: true
+dependencies: {  }
+_core:
+  default_config_hash: lBXDpdDPXQtrfTJQhr6MjRJJEEyYSoRJ0acdvHLsWeA
+id: en
+label: English
+direction: ltr
+weight: 0
+locked: false

--- a/config/default/language.entity.und.yml
+++ b/config/default/language.entity.und.yml
@@ -1,0 +1,11 @@
+uuid: bc3c5dcf-57ec-46b1-a8fd-cb42670ec1ba
+langcode: en
+status: true
+dependencies: {  }
+_core:
+  default_config_hash: eNX6lLCKDaY83nCMh20My---y03KbiFlv802DKCCpvg
+id: und
+label: 'Not specified'
+direction: ltr
+weight: 3
+locked: true

--- a/config/default/language.entity.zh-hans.yml
+++ b/config/default/language.entity.zh-hans.yml
@@ -1,0 +1,9 @@
+uuid: 8a1a1ef9-6894-4357-ac5c-3bbb14fda1cd
+langcode: en
+status: true
+dependencies: {  }
+id: zh-hans
+label: 'Chinese, Simplified'
+direction: ltr
+weight: 1
+locked: false

--- a/config/default/language.entity.zxx.yml
+++ b/config/default/language.entity.zxx.yml
@@ -1,0 +1,11 @@
+uuid: 4f37e056-9e4e-4b76-b483-31abc41f6ec2
+langcode: en
+status: true
+dependencies: {  }
+_core:
+  default_config_hash: 35CefWbnzaiytcg3acexxz_GTvuwIjYd_ZTcmmR-tXA
+id: zxx
+label: 'Not applicable'
+direction: ltr
+weight: 4
+locked: true

--- a/config/default/language.mappings.yml
+++ b/config/default/language.mappings.yml
@@ -1,0 +1,13 @@
+map:
+  'no': nb
+  pt: pt-pt
+  zh: zh-hans
+  zh-tw: zh-hant
+  zh-hk: zh-hant
+  zh-mo: zh-hant
+  zh-cht: zh-hant
+  zh-cn: zh-hans
+  zh-sg: zh-hans
+  zh-chs: zh-hans
+_core:
+  default_config_hash: EMWe7Yu4Q5eD-NUfNuQAWGBvYUNZPIinztEtONSmsDc

--- a/config/default/language.negotiation.yml
+++ b/config/default/language.negotiation.yml
@@ -1,0 +1,15 @@
+session:
+  parameter: language
+url:
+  source: path_prefix
+  prefixes:
+    en: ''
+    zh-hans: zh-hans
+    ar: ar
+  domains:
+    en: ''
+    zh-hans: ''
+    ar: ''
+selected_langcode: site_default
+_core:
+  default_config_hash: uEePITI9tV6WqzmsTb7MfPCi5yPWXSxAN1xeLcYFQbM

--- a/config/default/language.types.yml
+++ b/config/default/language.types.yml
@@ -1,0 +1,19 @@
+all:
+  - language_interface
+  - language_content
+  - language_url
+configurable:
+  - language_interface
+negotiation:
+  language_content:
+    enabled:
+      language-interface: 0
+  language_url:
+    enabled:
+      language-url: 0
+      language-url-fallback: 1
+  language_interface:
+    enabled:
+      language-url: 0
+_core:
+  default_config_hash: dqouFqVseNJNvEjsoYKxbinFOITuCxYhi4y2OTNQP_8

--- a/config/default/language/zh-hans/views.view.block_usage_agencies.yml
+++ b/config/default/language/zh-hans/views.view.block_usage_agencies.yml
@@ -1,0 +1,6 @@
+display:
+  default:
+    display_options:
+      footer:
+        result:
+          content: '<div class="grid-item"><span class="int"><span class="fancyCounter do-fade faded counted">@total</span></span><h3>代理商使用</h3></div>'

--- a/config/default/locale.settings.yml
+++ b/config/default/locale.settings.yml
@@ -1,0 +1,15 @@
+cache_strings: true
+translate_english: false
+javascript:
+  directory: languages
+translation:
+  use_source: remote_and_local
+  default_filename: '%project-%version.%language.po'
+  default_server_pattern: 'http://ftp.drupal.org/files/translations/%core/%project/%project-%version.%language.po'
+  overwrite_customized: false
+  overwrite_not_customized: true
+  update_interval_days: 0
+  path: sites/default/files/translations
+  import_enabled: true
+_core:
+  default_config_hash: Lqw8pAQIfr4sRSts2RRWG97eNG6vRT7FhqF_b5COPGk

--- a/config/default/user.role.layout_manager.yml
+++ b/config/default/user.role.layout_manager.yml
@@ -14,6 +14,7 @@ label: 'Layout manager'
 weight: 2
 is_admin: false
 permissions:
+  - 'administer govcms_dlm'
   - 'administer node display'
   - 'administer panelizer'
   - 'administer panelizer node knowledge_base defaults'

--- a/docroot/.gitattributes
+++ b/docroot/.gitattributes
@@ -35,6 +35,7 @@
 *.script  text eol=lf whitespace=blank-at-eol,-blank-at-eof,-space-before-tab,tab-in-indent,tabwidth=2
 *.sh      text eol=lf whitespace=blank-at-eol,-blank-at-eof,-space-before-tab,tab-in-indent,tabwidth=2 diff=php
 *.sql     text eol=lf whitespace=blank-at-eol,-blank-at-eof,-space-before-tab,tab-in-indent,tabwidth=2
+*.svg     text eol=lf whitespace=blank-at-eol,-blank-at-eof,-space-before-tab,tab-in-indent,tabwidth=2
 *.theme   text eol=lf whitespace=blank-at-eol,-blank-at-eof,-space-before-tab,tab-in-indent,tabwidth=2 diff=php
 *.twig    text eol=lf whitespace=blank-at-eol,-blank-at-eof,-space-before-tab,tab-in-indent,tabwidth=2
 *.txt     text eol=lf whitespace=blank-at-eol,-blank-at-eof,-space-before-tab,tab-in-indent,tabwidth=2

--- a/patches/drupal/core/views-block-context-duplication.patch
+++ b/patches/drupal/core/views-block-context-duplication.patch
@@ -1,0 +1,103 @@
+diff --git a/core/modules/contextual/js/contextual.js b/core/modules/contextual/js/contextual.js
+index 558ea10..dad93ed 100644
+--- a/core/modules/contextual/js/contextual.js
++++ b/core/modules/contextual/js/contextual.js
+@@ -160,6 +160,8 @@
+         ids.push($(this).attr('data-contextual-id'));
+       });
+ 
++      ids = _.uniq(ids);
++
+       // Update all contextual links placeholders whose HTML is cached.
+       var uncachedIDs = _.filter(ids, function initIfCached(contextualID) {
+         var html = storage.getItem('Drupal.contextual.' + contextualID);
+diff --git a/core/modules/views/src/Element/View.php b/core/modules/views/src/Element/View.php
+index 43d1058..8a585cc 100644
+--- a/core/modules/views/src/Element/View.php
++++ b/core/modules/views/src/Element/View.php
+@@ -80,15 +80,6 @@ public static function preRenderViewElement($element) {
+         if (isset($element['view_build']['#title'])) {
+           $element['#title'] = &$element['view_build']['#title'];
+         }
+-
+-        if (empty($view->display_handler->getPluginDefinition()['returns_response'])) {
+-          // views_add_contextual_links() needs the following information in
+-          // order to be attached to the view.
+-          $element['#view_id'] = $view->storage->id();
+-          $element['#view_display_show_admin_links'] = $view->getShowAdminLinks();
+-          $element['#view_display_plugin_id'] = $view->display_handler->getPluginId();
+-          views_add_contextual_links($element, 'view', $view->current_display);
+-        }
+       }
+       if (empty($view->display_handler->getPluginDefinition()['returns_response'])) {
+         $element['#attributes']['class'][] = 'views-element-container';
+diff --git a/core/modules/views/src/Plugin/Block/ViewsBlock.php b/core/modules/views/src/Plugin/Block/ViewsBlock.php
+index 34738cd..a065799 100644
+--- a/core/modules/views/src/Plugin/Block/ViewsBlock.php
++++ b/core/modules/views/src/Plugin/Block/ViewsBlock.php
+@@ -49,10 +49,6 @@ public function build() {
+     // entry for the view output by passing FALSE, because we're going to cache
+     // the whole block instead.
+     if ($output = $this->view->buildRenderable($this->displayID, array_values($args), FALSE)) {
+-      // Before returning the block output, convert it to a renderable array
+-      // with contextual links.
+-      $this->addContextualLinks($output);
+-
+       // Block module expects to get a final render array, without another
+       // top-level #pre_render callback. So, here we make sure that Views'
+       // #pre_render callback has already been applied.
+diff --git a/core/modules/views/src/Plugin/Block/ViewsBlockBase.php b/core/modules/views/src/Plugin/Block/ViewsBlockBase.php
+index 4e3020c..1771720 100644
+--- a/core/modules/views/src/Plugin/Block/ViewsBlockBase.php
++++ b/core/modules/views/src/Plugin/Block/ViewsBlockBase.php
+@@ -186,24 +186,10 @@ public function blockSubmit($form, FormStateInterface $form_state) {
+    * @param string $block_type
+    *   The type of the block. If it's 'block' it's a regular views display,
+    *   but 'exposed_filter' exist as well.
++   *
++   * @deprecated Contextual links now applied via DisplayPluginBase.
+    */
+   protected function addContextualLinks(&$output, $block_type = 'block') {
+-    // Do not add contextual links to an empty block.
+-    if (!empty($output)) {
+-      // Contextual links only work on blocks whose content is a renderable
+-      // array, so if the block contains a string of already-rendered markup,
+-      // convert it to an array.
+-      if (is_string($output)) {
+-        $output = ['#markup' => $output];
+-      }
+-
+-      // views_add_contextual_links() needs the following information in
+-      // order to be attached to the view.
+-      $output['#view_id'] = $this->view->storage->id();
+-      $output['#view_display_show_admin_links'] = $this->view->getShowAdminLinks();
+-      $output['#view_display_plugin_id'] = $this->view->display_handler->getPluginId();
+-      views_add_contextual_links($output, $block_type, $this->displayID);
+-    }
+   }
+ 
+ }
+diff --git a/core/modules/views/src/Plugin/views/display/DisplayPluginBase.php b/core/modules/views/src/Plugin/views/display/DisplayPluginBase.php
+index e31b5a2..5292c81 100644
+--- a/core/modules/views/src/Plugin/views/display/DisplayPluginBase.php
++++ b/core/modules/views/src/Plugin/views/display/DisplayPluginBase.php
+@@ -2323,6 +2323,9 @@ public function buildRenderable(array $args = [], $cache = TRUE) {
+       '#embed' => FALSE,
+       '#view' => $this->view,
+       '#cache_properties' => ['#view_id', '#view_display_show_admin_links', '#view_display_plugin_id'],
++      '#view_display_show_admin_links' => $this->view->getShowAdminLinks(),
++      '#view_display_plugin_id' => $this->display['display_plugin'],
++      '#view_id' => $this->view->storage->id(),
+     ];
+ 
+     // When something passes $cache = FALSE, they're asking us not to create our
+@@ -2344,6 +2347,9 @@ public function buildRenderable(array $args = [], $cache = TRUE) {
+       unset($this->view->element['#cache']['keys']);
+     }
+ 
++    // Attach the contextual links directly to the view.
++    views_add_contextual_links($this->view->element, "block", $this->display['id']);
++
+     return $this->view->element;
+   }
+ 


### PR DESCRIPTION
- Enables multilingual modules.
- Configures the content types (basic page and article) to be multilingual.
- Adds language switcher block.