### PR TITLE
GDE-032: Enable drop-down menu for all links with children.

### DIFF
--- a/config/default/core.extension.yml
+++ b/config/default/core.extension.yml
@@ -32,6 +32,7 @@ module:
   field_ui: 0
   file: 0
   filter: 0
+  govcms_base: 0
   govcms_consultation: 0
   govcms_dlm: 0
   govcms_draft_content_access: 0

--- a/docroot/modules/custom/govcms_base/govcms_base.info.yml
+++ b/docroot/modules/custom/govcms_base/govcms_base.info.yml
@@ -1,0 +1,4 @@
+name: 'govCMS Base'
+description: 'Provides basic customisations for the govCMS site.'
+type: module
+core: 8.x

--- a/docroot/modules/custom/govcms_base/govcms_base.install
+++ b/docroot/modules/custom/govcms_base/govcms_base.install
@@ -1,0 +1,51 @@
+<?php
+
+/**
+ * @file
+ * Provides install & update hooks for the govCMS Base module.
+ */
+
+/**
+ * Implements hook_install().
+ */
+function govcms_base_install() {
+  _expand_menu_links_with_children();
+}
+
+/**
+ * Update menu links with children to display as expanded.
+ */
+function _expand_menu_links_with_children() {
+  $menu_tree = \Drupal::menuTree();
+  $menu_name = 'main';
+
+  // Build the typical default set of menu tree parameters.
+  $parameters = $menu_tree->getCurrentRouteMenuTreeParameters($menu_name);
+
+  // Load the tree based on this set of parameters.
+  $main_menu_tree = $menu_tree->load($menu_name, $parameters);
+  $ids_to_update = [];
+
+  /** @var \Drupal\Core\Menu\MenuLinkTreeElement $tree_element */
+  foreach ($main_menu_tree as $id => $tree_element) {
+    if ($tree_element->hasChildren) {
+      /** @var \Drupal\menu_link_content\Plugin\Menu\MenuLinkContent $link_content */
+      $link_content = $tree_element->link;
+      $definition = $link_content->getPluginDefinition();
+      if ($definition['expanded'] == 1) {
+        continue;
+      }
+      $ids_to_update[] = $id;
+    }
+  }
+
+  // Update the table directly to expand the menu links.
+  if (!empty($ids_to_update)) {
+    $connection = \Drupal::database();
+    $connection
+      ->update('menu_tree')
+      ->fields(['expanded' => 1])
+      ->condition('id', $ids_to_update, 'IN')
+      ->execute();
+  }
+}

--- a/docroot/themes/custom/govcms_uikit_starterkit/govcms_uikit_starterkit.libraries.yml
+++ b/docroot/themes/custom/govcms_uikit_starterkit/govcms_uikit_starterkit.libraries.yml
@@ -13,6 +13,7 @@ global_styles:
     js/morph_dropdown.js: {}
     js/uikit.min.js: {}
   dependencies:
+    - core/drupal
     - core/jquery
 
 uikit:


### PR DESCRIPTION
 - Created a custom module and updated the link expanded attribute via the install hook.
 - Enabled the module via config.
 - Updated the theme libraries to add core/drupal as dependency otherwise anonymous cannot load the JS properly.