### PR TITLE
GDE-43: Fix Trusted By view logos.

### DIFF
--- a/config/default/image.style.logo.yml
+++ b/config/default/image.style.logo.yml
@@ -1,0 +1,15 @@
+uuid: 5560960e-ba44-40aa-8880-178eedc70339
+langcode: en
+status: true
+dependencies: {  }
+name: logo
+label: Logo
+effects:
+  5de01ba0-c122-4d16-9b12-4c7c8168ef0b:
+    uuid: 5de01ba0-c122-4d16-9b12-4c7c8168ef0b
+    id: image_scale
+    weight: 1
+    data:
+      width: 350
+      height: null
+      upscale: false

--- a/config/default/views.view.block_trusted_logos.yml
+++ b/config/default/views.view.block_trusted_logos.yml
@@ -6,6 +6,7 @@ dependencies:
     - field.storage.node.field_agency
     - field.storage.node.field_link
     - field.storage.taxonomy_term.field_logo
+    - image.style.logo
     - node.type.site
     - taxonomy.vocabulary.status
   content:
@@ -185,7 +186,7 @@ display:
           click_sort_column: target_id
           type: image
           settings:
-            image_style: ''
+            image_style: logo
             image_link: ''
           group_column: ''
           group_columns: {  }

--- a/docroot/themes/custom/govcms_uikit_starterkit/sass/components/_trusted_by.scss
+++ b/docroot/themes/custom/govcms_uikit_starterkit/sass/components/_trusted_by.scss
@@ -17,8 +17,8 @@
 
     > .views-row {
       img {
-        max-height: 158px;
-        width: auto;
+        max-width: 100%;
+        height: auto;
       }
 
       a {


### PR DESCRIPTION
 - Created a logo image style and used it in the view.
 - Maxed on width instead of height, and set height to auto.